### PR TITLE
feat: add setup and configuration scripts

### DIFF
--- a/scripts/configure-gateway-manager.sh
+++ b/scripts/configure-gateway-manager.sh
@@ -1,0 +1,511 @@
+#!/bin/bash
+# Configure Gateway Manager - https://docs.itential.com/docs/gateway-manager-release-notes
+# Uploads certificates and creates gateway cluster via REST
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# wait for gw manager api to be ready
+wait_for_gateway_manager_api() {
+    local max_wait=60
+    local interval=3
+
+    log_info "Waiting for Gateway Manager API to initialize..."
+
+    for ((i=0; i<max_wait; i+=interval)); do
+        local http_code
+        http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+            "${PLATFORM_URL}/gateway_manager/v1/certificates" \
+            -b "$COOKIE_JAR" 2>/dev/null)
+
+        if [ "$http_code" = "200" ]; then
+            log_info "Gateway Manager API is ready"
+            return 0
+        fi
+
+        sleep "$interval"
+    done
+
+    log_warn "Gateway Manager API readiness timeout, proceeding anyway..."
+    return 1
+}
+
+# check for jq (required for JSON handling)
+if ! command -v jq &>/dev/null; then
+    log_error "jq is required but not installed. Install with applicable package manager."
+    exit 1
+fi
+
+# load env
+if [ -f "$PROJECT_ROOT/.env" ]; then
+    source "$PROJECT_ROOT/.env"
+fi
+
+# configuration
+PLATFORM_URL="${PLATFORM_URL:-http://localhost:${PLATFORM_PORT:-3000}}"
+
+# default admin credentials for initial setup
+ADMIN_USER="admin"
+ADMIN_PASSWORD="admin"
+
+CLUSTER_ID="${GATEWAY5_CLUSTER_ID:-cluster_1}"
+CERT_FILE="$PROJECT_ROOT/volumes/gateway5/certificates/gw-manager.pem"
+KEY_FILE="$PROJECT_ROOT/volumes/gateway5/certificates/gw-manager-key.pem"
+
+# cookie jar for authenticated api calls
+COOKIE_JAR=$(mktemp)
+trap "rm -f $COOKIE_JAR" EXIT
+
+log_info "Configuring Gateway Manager..."
+log_info "Platform URL: $PLATFORM_URL"
+log_info "Cluster ID: $CLUSTER_ID"
+
+# do certificate files exist?
+if [ ! -f "$CERT_FILE" ]; then
+    log_error "Certificate file not found: $CERT_FILE"
+    log_info "Run: ./scripts/generate-certificates.sh"
+    exit 1
+fi
+
+if [ ! -f "$KEY_FILE" ]; then
+    log_error "Key file not found: $KEY_FILE"
+    log_info "Run: ./scripts/generate-certificates.sh"
+    exit 1
+fi
+
+log_info "Certificate files found"
+
+# wait for platform to be accessible
+log_info "Waiting for Platform API..."
+MAX_WAIT=60
+for ((i=0; i<MAX_WAIT; i+=2)); do
+
+    # is platform responding?
+    if curl -sf "${PLATFORM_URL}/" &>/dev/null; then
+        log_info "Platform is accessible"
+        break
+    fi
+    if [ $i -ge $((MAX_WAIT - 2)) ]; then
+        log_error "Platform not accessible after ${MAX_WAIT}s"
+        exit 1
+    fi
+    sleep 2
+done
+
+# add additional time for internal services to fully initialize
+PLATFORM_INIT_DELAY="${PLATFORM_INIT_DELAY:-10}"
+log_info "Waiting ${PLATFORM_INIT_DELAY}s for Platform internal services to initialize..."
+sleep "$PLATFORM_INIT_DELAY"
+
+# initial setup done with `admin`
+log_info "Authenticating as admin..."
+LOGIN_RESPONSE=$(curl -sf -X POST "${PLATFORM_URL}/login" \
+    -H "Content-Type: application/json" \
+    -c "$COOKIE_JAR" \
+    -d "{\"username\":\"${ADMIN_USER}\",\"password\":\"${ADMIN_PASSWORD}\"}" 2>/dev/null) || {
+    log_warn "Could not authenticate (Platform may still be initializing)"
+    LOGIN_RESPONSE=""
+}
+
+if [ -n "$LOGIN_RESPONSE" ]; then
+    log_info "Authenticated successfully"
+
+    # wait for gateway manager api before proceeding
+    wait_for_gateway_manager_api
+fi
+
+# role ids for permissions (looked up dynamically)
+ROLE_GATEWAY_READ=""
+ROLE_GATEWAY_UPDATE=""
+ROLE_GATEWAY_CREATE=""
+ALL_ROLE_IDS=""
+
+lookup_all_roles() {
+    log_info "Looking up all role IDs..."
+    local roles_response
+    roles_response=$(curl -sf "${PLATFORM_URL}/authorization/roles?limit=200" -b "$COOKIE_JAR" 2>/dev/null)
+
+    # build json array of all role ids -> for assignment
+    ALL_ROLE_IDS=$(echo "$roles_response" | jq -c '[.results[] | {roleId: ._id}]')
+
+    # still extract gateway roles for logging
+    ROLE_GATEWAY_READ=$(echo "$roles_response" | jq -r '.results[] | select(.name == "gateway:read") | ._id')
+    ROLE_GATEWAY_UPDATE=$(echo "$roles_response" | jq -r '.results[] | select(.name == "gateway:update") | ._id')
+    ROLE_GATEWAY_CREATE=$(echo "$roles_response" | jq -r '.results[] | select(.name == "gateway:create") | ._id')
+
+    local role_count
+    role_count=$(echo "$roles_response" | jq '.results | length')
+    log_info "Found $role_count roles total (including gateway:read, gateway:update, gateway:create)"
+
+    if [ -z "$ALL_ROLE_IDS" ] || [ "$ALL_ROLE_IDS" = "[]" ]; then
+        log_warn "Could not find any roles"
+        return 1
+    fi
+    return 0
+}
+
+# global vars to store certificate id for gateway creation
+CERT_ID=""
+
+# --- API Functions ---
+
+upload_certificate() {
+    local cert_name="gateway5-${CLUSTER_ID}"
+    local cert_content
+    cert_content=$(jq -Rs '.' "$CERT_FILE")
+
+    # do certs already exist?
+    local existing_id
+    existing_id=$(curl -sf "${PLATFORM_URL}/gateway_manager/v1/certificates" \
+        -b "$COOKIE_JAR" 2>/dev/null | jq -r ".results[] | select(.alias == \"${cert_name}\") | ._id") || true
+
+    if [ -n "$existing_id" ]; then
+        log_info "Certificate '$cert_name' already exists (ID: $existing_id)"
+        CERT_ID="$existing_id"
+        return 0
+    fi
+
+    log_info "Uploading certificate '$cert_name'..."
+
+    local max_attempts=5
+    local delay=3
+
+    for ((attempt=1; attempt<=max_attempts; attempt++)); do
+        local response http_code
+        response=$(curl -s -w "\n%{http_code}" -X POST "${PLATFORM_URL}/gateway_manager/v1/certificates" \
+            -H "Content-Type: application/json" \
+            -b "$COOKIE_JAR" \
+            -d "{\"raw_certificate\":${cert_content},\"contract_id\":\"${cert_name}\",\"alias\":\"${cert_name}\"}" 2>/dev/null)
+
+        http_code=$(echo "$response" | tail -1)
+        response=$(echo "$response" | head -n -1)
+
+        # success!
+        if [ "$http_code" = "200" ] || [ "$http_code" = "201" ]; then
+
+            # try different response formats
+            CERT_ID=$(echo "$response" | jq -r '.data._id // .results.upsertedIds["0"] // empty')
+            if [ -n "$CERT_ID" ] && [ "$CERT_ID" != "null" ]; then
+                log_info "Certificate uploaded (ID: $CERT_ID)"
+                return 0
+            fi
+            # if id extraction fails but http returns 200, certificate may still be uploaded
+            # does it exist now?
+            sleep 1
+            existing_id=$(curl -sf "${PLATFORM_URL}/gateway_manager/v1/certificates" \
+                -b "$COOKIE_JAR" 2>/dev/null | jq -r ".results[] | select(.alias == \"${cert_name}\") | ._id") || true
+            if [ -n "$existing_id" ]; then
+                log_info "Certificate '$cert_name' uploaded (ID: $existing_id)"
+                CERT_ID="$existing_id"
+                return 0
+            fi
+        fi
+
+        # already exists!
+        if [ "$http_code" = "409" ]; then
+            existing_id=$(curl -sf "${PLATFORM_URL}/gateway_manager/v1/certificates" \
+                -b "$COOKIE_JAR" 2>/dev/null | jq -r ".results[] | select(.alias == \"${cert_name}\") | ._id") || true
+            if [ -n "$existing_id" ]; then
+                log_info "Certificate '$cert_name' already exists (ID: $existing_id)"
+                CERT_ID="$existing_id"
+                return 0
+            fi
+        fi
+
+        # retry on connection errors or service unavailable
+        if [ $attempt -lt $max_attempts ]; then
+            case "$http_code" in
+                000|502|503|504)
+                    log_warn "Gateway Manager not ready (HTTP $http_code), retrying in ${delay}s... ($attempt/$max_attempts)"
+                    sleep "$delay"
+                    delay=$((delay + 2))
+                    continue
+                    ;;
+            esac
+        fi
+
+        log_warn "Certificate upload failed (HTTP $http_code)"
+        return 1
+    done
+
+    log_warn "Certificate upload failed after $max_attempts attempts"
+    return 1
+}
+
+ensure_admin_group() {
+    local group_name="admin_group"
+
+    # does group exist?
+    local existing
+    existing=$(curl -sf "${PLATFORM_URL}/authorization/groups?limit=100" \
+        -b "$COOKIE_JAR" 2>/dev/null | jq -r ".results[] | select(.name == \"${group_name}\") | ._id") || true
+
+    if [ -n "$existing" ]; then
+        log_info "Group '$group_name' already exists (ID: $existing), updating with all roles..." >&2
+
+        # update group with ALL roles
+        curl -sf -X PATCH "${PLATFORM_URL}/authorization/groups/${existing}" \
+            -H "Content-Type: application/json" \
+            -b "$COOKIE_JAR" \
+            -d "{\"updates\":{\"assignedRoles\":${ALL_ROLE_IDS}}}" 2>/dev/null > /dev/null || true
+        echo "$existing"
+        return 0
+    fi
+
+    # create group with ALL roles
+    log_info "Creating group '$group_name' with all roles..." >&2
+    local response
+    response=$(curl -sf -X POST "${PLATFORM_URL}/authorization/groups" \
+        -H "Content-Type: application/json" \
+        -b "$COOKIE_JAR" \
+        -d "{\"group\":{\"name\":\"${group_name}\",\"provenance\":\"Pronghorn\",\"description\":\"Admin group with full permissions\",\"assignedRoles\":${ALL_ROLE_IDS},\"memberOf\":[],\"inactive\":false}}" 2>/dev/null) || {
+        log_warn "Failed to create group"
+        return 1
+    }
+
+    local group_id
+    group_id=$(echo "$response" | jq -r '.data._id // empty')
+    if [ -n "$group_id" ]; then
+        log_info "Group '$group_name' created (ID: $group_id)" >&2
+        echo "$group_id"
+        return 0
+    fi
+
+    log_warn "Group creation response unexpected"
+    return 1
+}
+
+assign_user_permissions() {
+    local account_id="$1"
+    local group_id="$2"
+
+    log_info "Assigning group membership and all roles in single operation..."
+
+    # build json payload using jq / avoid string interpolation issues
+    local payload
+    payload=$(jq -n -c \
+        --arg gid "$group_id" \
+        --argjson roles "$ALL_ROLE_IDS" \
+        '{updates: {memberOf: [{aaaManaged: false, groupId: $gid}], assignedRoles: $roles}}')
+
+    local response
+    response=$(curl -s -X PATCH "${PLATFORM_URL}/authorization/accounts/${account_id}" \
+        -H "Content-Type: application/json" \
+        -b "$COOKIE_JAR" \
+        -d "$payload" 2>/dev/null)
+
+    if echo "$response" | jq -e '.status == "OK"' &>/dev/null; then
+        log_info "User permissions assigned successfully"
+        return 0
+    else
+        log_warn "Failed to assign user permissions: $response"
+        return 1
+    fi
+}
+
+create_gateway() {
+    log_info "Creating gateway cluster '$CLUSTER_ID'..."
+
+    # does gateway already exist?
+    local existing
+    existing=$(curl -sf "${PLATFORM_URL}/gateway_manager/v1/gateways" \
+        -b "$COOKIE_JAR" 2>/dev/null | jq -r ".results[]? | select(.cluster_id == \"${CLUSTER_ID}\") | .cluster_id") || true
+
+    if [ "$existing" = "$CLUSTER_ID" ]; then
+        log_info "Gateway cluster '$CLUSTER_ID' already exists"
+        return 0
+    fi
+
+    # verify certificate id
+    if [ -z "$CERT_ID" ]; then
+        log_warn "No certificate ID available - gateway may not connect properly"
+    fi
+
+    # gateway requires a group and certificate reference for link to work
+    local response http_code
+    response=$(curl -s -w "\n%{http_code}" -X POST "${PLATFORM_URL}/gateway_manager/v1/gateways" \
+        -H "Content-Type: application/json" \
+        -b "$COOKIE_JAR" \
+        -d "{\"gateway\":{\"cluster_id\":\"${CLUSTER_ID}\",\"description\":\"Auto-configured gateway\",\"enabled\":true,\"readonly\":false,\"certificates\":[\"${CERT_ID}\"],\"groups\":[\"admin_group\"]}}" 2>/dev/null)
+
+    http_code=$(echo "$response" | tail -1)
+    response=$(echo "$response" | head -n -1)
+
+    if [ "$http_code" = "200" ] || [ "$http_code" = "201" ]; then
+        log_info "Gateway cluster created with certificate and enabled"
+        return 0
+    elif [ "$http_code" = "409" ]; then
+        log_info "Gateway cluster '$CLUSTER_ID' already exists"
+        return 0
+    else
+        log_warn "Gateway cluster creation failed (HTTP $http_code): $response"
+        return 1
+    fi
+}
+
+verify_connection() {
+    log_info "Waiting for Gateway5 to connect..."
+    for i in {1..12}; do
+        local response
+
+        # check all connections and look for our cluster
+        response=$(curl -sf "${PLATFORM_URL}/gateway_manager/v1/connections" \
+            -b "$COOKIE_JAR" 2>/dev/null) || true
+        if [ -n "$response" ] && echo "$response" | jq -e ".\"${CLUSTER_ID}\"" &>/dev/null; then
+            log_info "Gateway5 connected successfully!"
+            return 0
+        fi
+        sleep 5
+    done
+    log_warn "Gateway5 not yet connected (will connect when container starts)"
+    return 0
+}
+
+# --- phase 1: setup ---
+# upload cert / create admin group
+
+CERT_UPLOADED=false
+GROUP_CREATED=false
+GATEWAY_CREATED=false
+
+if [ -n "$LOGIN_RESPONSE" ]; then
+    log_info "=== Phase 1: Initial Setup (as built-in admin) ==="
+
+    # look up ALL role ids (they vary per instance)
+    if ! lookup_all_roles; then
+        log_warn "Could not look up roles, gateway creation may fail"
+    fi
+
+    # upload cert
+    if upload_certificate; then
+        CERT_UPLOADED=true
+    fi
+
+    # create admin_group with ALL roles
+    GROUP_ID=$(ensure_admin_group)
+    if [ -n "$GROUP_ID" ]; then
+        GROUP_CREATED=true
+
+        # assign roles and group membership to admin user
+        ROLES_ASSIGNED=false
+        ADMIN_ACCOUNT_ID="000000000000000000000000"  # built-in admin has fixed id
+        if assign_user_permissions "$ADMIN_ACCOUNT_ID" "$GROUP_ID"; then
+            ROLES_ASSIGNED=true
+            log_info "Admin user configured with roles and group membership"
+        else
+            log_warn "Failed to configure admin permissions - gateway creation may fail"
+        fi
+    fi
+
+    # attempt gateway creation (requires roles to be assigned)
+    if [ "$CERT_UPLOADED" = true ] && [ "$GROUP_CREATED" = true ] && [ "$ROLES_ASSIGNED" = true ]; then
+        log_info "Attempting gateway cluster creation..."
+        if create_gateway; then
+            GATEWAY_CREATED=true
+        fi
+    else
+        if [ "$ROLES_ASSIGNED" != true ]; then
+            log_warn "Skipping gateway creation - admin roles not assigned"
+        fi
+    fi
+
+    if [ "$GATEWAY_CREATED" = true ]; then
+        verify_connection
+        log_info "Gateway Manager configured successfully via API!"
+        echo ""
+        log_info "Configuration complete. Verify with: make status"
+        log_info "Login as: admin / admin"
+        exit 0
+    fi
+fi
+
+# show status and any remaining manual steps
+echo ""
+echo -e "${BOLD}${CYAN}═══════════════════════════════════════════════════════════════${NC}"
+echo -e "${BOLD}${CYAN}  Gateway Manager Configuration Status${NC}"
+echo -e "${BOLD}${CYAN}═══════════════════════════════════════════════════════════════${NC}"
+echo ""
+
+# show what was accomplished
+if [ "$CERT_UPLOADED" = true ]; then
+    echo -e "${GREEN}✓${NC} Certificate '${BOLD}gateway5-${CLUSTER_ID}${NC}' uploaded"
+else
+    echo -e "${RED}✗${NC} Certificate upload failed"
+fi
+
+if [ "$GROUP_CREATED" = true ]; then
+    echo -e "${GREEN}✓${NC} Group '${BOLD}admin_group${NC}' configured with gateway roles"
+else
+    echo -e "${YELLOW}○${NC} Group 'admin_group' may need configuration"
+fi
+
+if [ "$GATEWAY_CREATED" = true ]; then
+    echo -e "${GREEN}✓${NC} Gateway cluster '${BOLD}${CLUSTER_ID}${NC}' created"
+    echo ""
+    log_info "Configuration complete. Verify with: make status"
+    exit 0
+fi
+
+# gateway not created - show manual steps (failback)
+echo ""
+echo -e "${BOLD}${CYAN}───────────────────────────────────────────────────────────────${NC}"
+echo -e "${BOLD}Remaining Manual Step:${NC} Create the gateway cluster in the UI"
+echo -e "${BOLD}${CYAN}───────────────────────────────────────────────────────────────${NC}"
+echo ""
+echo -e "  ${CYAN}1.${NC} Login to Platform: ${BOLD}${PLATFORM_URL}${NC}"
+echo -e "     (admin / admin)"
+echo ""
+
+STEP=2
+if [ "$GROUP_CREATED" = false ]; then
+    echo -e "  ${CYAN}${STEP}.${NC} Navigate to: ${BOLD}Admin Essentials → Authorization → Groups${NC}"
+    echo -e "     - Create group '${BOLD}admin_group${NC}'"
+    echo -e "     - Under ${BOLD}Roles${NC} tab, add: gateway:read, gateway:update, gateway:create"
+    echo -e "     - Click ${BOLD}Save${NC}"
+    echo ""
+    STEP=$((STEP + 1))
+fi
+
+echo -e "  ${CYAN}${STEP}.${NC} Navigate to: ${BOLD}Admin Essentials → Gateway Manager${NC}"
+STEP=$((STEP + 1))
+
+echo ""
+echo -e "  ${CYAN}${STEP}.${NC} Create new cluster:"
+echo -e "     - Cluster ID: ${BOLD}${CLUSTER_ID}${NC}"
+echo -e "     - Select certificate: ${BOLD}gateway5-${CLUSTER_ID}${NC}"
+echo -e "     - Assign to group: ${BOLD}admin_group${NC}"
+echo -e "     - Enable the cluster"
+echo ""
+
+if [ "$CERT_UPLOADED" = false ]; then
+    echo -e "${BOLD}${CYAN}───────────────────────────────────────────────────────────────${NC}"
+    echo -e "${BOLD}Certificate Content (copy/paste into Platform):${NC}"
+    echo -e "${BOLD}${CYAN}───────────────────────────────────────────────────────────────${NC}"
+    echo ""
+    cat "$CERT_FILE"
+    echo ""
+    echo -e "${BOLD}${CYAN}───────────────────────────────────────────────────────────────${NC}"
+fi
+
+echo ""
+echo -e "${BOLD}After configuration:${NC}"
+echo -e "  - Gateway5 will connect automatically when started"
+echo -e "  - Check logs: ${BOLD}docker logs platform${NC}"
+echo -e "  - Verify status: ${BOLD}make status${NC}"
+echo ""
+
+log_info "Manual steps required to complete gateway cluster setup"

--- a/scripts/generate-certificates.sh
+++ b/scripts/generate-certificates.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+# Generate SSL certificates for Platform and Gateway5 integration
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+PLATFORM_SSL_DIR="$PROJECT_ROOT/volumes/platform/ssl"
+GATEWAY5_CERTS_DIR="$PROJECT_ROOT/volumes/gateway5/certificates"
+
+# defaults
+FORCE=false
+QUIET=false
+
+# parse args (see --help for usage)
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -f|--force)
+            FORCE=true
+            shift
+            ;;
+        -q|--quiet)
+            QUIET=true
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $(basename "$0") [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  -f, --force   Force regenerate all certificates"
+            echo "  -q, --quiet   Minimal output (for CI/CD)"
+            echo "  -h, --help    Show this help message"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# logging
+log() {
+    if [ "$QUIET" = false ]; then
+        echo "$1"
+    fi
+}
+
+log_success() {
+    if [ "$QUIET" = false ]; then
+        echo "✓ $1"
+    fi
+}
+
+log_info() {
+    if [ "$QUIET" = false ]; then
+        echo "→ $1"
+    fi
+}
+
+log_warn() {
+    if [ "$QUIET" = false ]; then
+        echo "⚠ $1"
+    fi
+}
+
+# header
+if [ "$QUIET" = false ]; then
+    echo "--- certificate generation ---"
+    echo ""
+fi
+
+# create directories
+mkdir -p "$PLATFORM_SSL_DIR"
+mkdir -p "$GATEWAY5_CERTS_DIR"
+
+# check if cert file exists and is valid
+check_cert_exists() {
+    local file=$1
+    if [ -f "$file" ]; then
+        if [ -s "$file" ] && grep -q "BEGIN" "$file"; then
+            return 0
+        fi
+    fi
+    return 1
+}
+
+# should we generate?
+should_generate() {
+    local cert_file=$1
+    local key_file=$2
+
+    if [ "$FORCE" = true ]; then
+        return 0
+    fi
+
+    if check_cert_exists "$cert_file" && check_cert_exists "$key_file"; then
+        return 1
+    fi
+
+    return 0
+}
+
+# --- platform ssl ---
+log "[1/2] checking platform ssl certificates..."
+
+if should_generate "$PLATFORM_SSL_DIR/cert.pem" "$PLATFORM_SSL_DIR/key.pem"; then
+    log_info "generating platform ssl certificates..."
+    openssl req -x509 -newkey rsa:4096 \
+        -keyout "$PLATFORM_SSL_DIR/key.pem" \
+        -out "$PLATFORM_SSL_DIR/cert.pem" \
+        -days 1825 -nodes \
+        -subj "/CN=localhost" \
+        -addext "subjectAltName=DNS:localhost,DNS:platform,IP:127.0.0.1" \
+        -addext "basicConstraints=CA:FALSE" \
+        -addext "keyUsage=digitalSignature,keyEncipherment" \
+        -addext "extendedKeyUsage=serverAuth" 2>/dev/null
+
+    if [ $? -eq 0 ]; then
+        log_success "platform ssl certificates generated"
+        log "  location: $PLATFORM_SSL_DIR"
+    else
+        echo "✗ failed to generate platform ssl certificates"
+        exit 1
+    fi
+else
+    log_success "platform ssl certificates already exist (use --force to regenerate)"
+fi
+
+# --- gateway5 certs ---
+log ""
+log "[2/2] checking gateway5 certificates..."
+
+if should_generate "$GATEWAY5_CERTS_DIR/gw-manager.pem" "$GATEWAY5_CERTS_DIR/gw-manager-key.pem"; then
+    log_info "generating gateway5 client certificates..."
+    openssl req -x509 -newkey rsa:4096 \
+        -keyout "$GATEWAY5_CERTS_DIR/gw-manager-key.pem" \
+        -out "$GATEWAY5_CERTS_DIR/gw-manager.pem" \
+        -days 1825 -nodes \
+        -subj "/CN=gateway5" \
+        -addext "subjectAltName=DNS:gateway5,DNS:localhost,IP:127.0.0.1" \
+        -addext "basicConstraints=CA:FALSE" \
+        -addext "keyUsage=digitalSignature,keyEncipherment" \
+        -addext "extendedKeyUsage=clientAuth,serverAuth" 2>/dev/null
+
+    if [ $? -eq 0 ]; then
+        log_success "gateway5 certificates generated"
+        log "  location: $GATEWAY5_CERTS_DIR"
+    else
+        echo "✗ failed to generate gateway5 certificates"
+        exit 1
+    fi
+else
+    log_success "gateway5 certificates already exist (use --force to regenerate)"
+fi
+
+# --- permissions ---
+log ""
+log "setting file permissions..."
+
+# platform runs as uid 1001
+if command -v chown &> /dev/null && [ "$(id -u)" = "0" ]; then
+    chown -R 1001:1001 "$PLATFORM_SSL_DIR"
+    log_success "platform ssl directory ownership set to uid 1001"
+else
+    log_warn "skipping ownership change (requires root)"
+fi
+
+# gateway5 runs as uid 100
+if command -v chown &> /dev/null && [ "$(id -u)" = "0" ]; then
+    chown -R 100:101 "$GATEWAY5_CERTS_DIR"
+    log_success "gateway5 certificates directory ownership set to uid 100"
+else
+    log_warn "skipping ownership change (requires root)"
+fi
+
+# make files readable
+chmod 644 "$PLATFORM_SSL_DIR"/*.pem 2>/dev/null || true
+chmod 644 "$GATEWAY5_CERTS_DIR"/*.pem 2>/dev/null || true
+log_success "file permissions set to 644"
+
+if [ "$QUIET" = false ]; then
+    echo ""
+    echo "--- certificate generation complete ---"
+    echo ""
+    echo "next steps:"
+    echo "  make up       # start all services"
+    echo "  make status   # check service status"
+    echo ""
+fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+# First-time setup - creates env, generates certs, starts services
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+log_section() { echo -e "\n${BLUE}--- $1 ---${NC}"; }
+
+# are images present locally?
+check_images_present() {
+    local ecr="${ECR_REGISTRY:-497639811223.dkr.ecr.us-east-2.amazonaws.com}"
+    local platform_ver="${PLATFORM_VERSION:-6}"
+    local gw4_ver="${GATEWAY4_VERSION:-4.3.7}"
+    local gw5_ver="${GATEWAY5_VERSION:-5.1.0-amd64}"
+
+    local images=(
+        "${ecr}/automation-platform-config-lcm:${platform_ver}"
+        "${ecr}/automation-gateway:${gw4_ver}"
+        "${ecr}/automation-gateway5:${gw5_ver}"
+    )
+
+    for img in "${images[@]}"; do
+        if ! docker image inspect "$img" &>/dev/null; then
+            return 1
+        fi
+    done
+    return 0
+}
+
+cd "$PROJECT_ROOT"
+
+echo -e "${BLUE}"
+echo "  ___  _             _   _       _"
+echo " |_ _|| |_ ___ _ __ | |_(_) __ _| |"
+echo "  | | | __/ _ \ '_ \| __| |/ _\` | |"
+echo "  | | | ||  __/ | | | |_| | (_| | |"
+echo " |___||_| \___|_| |_|\__|_|\__,_|_|"
+echo ""
+echo " Dev Stack Setup"
+echo -e "${NC}"
+
+log_section "pre-flight checks"
+
+# docker installed?
+if ! command -v docker &>/dev/null; then
+    log_error "Docker is not installed. Please install Docker first."
+    exit 1
+fi
+log_info "Docker: $(docker --version | cut -d' ' -f3 | tr -d ',')"
+
+# docker compose available?
+if ! docker compose version &>/dev/null; then
+    log_error "Docker Compose is not available. Please install Docker Compose v2+."
+    exit 1
+fi
+log_info "Docker Compose: $(docker compose version --short)"
+
+# check images early to skip aws cli if not needed
+IMAGES_PRESENT=false
+if check_images_present; then
+    IMAGES_PRESENT=true
+fi
+
+# aws cli (only if images need pulling)
+if [ "$IMAGES_PRESENT" = false ]; then
+    if ! command -v aws &>/dev/null; then
+        log_error "AWS CLI is not installed. Required for ECR authentication."
+        exit 1
+    fi
+    log_info "AWS CLI: installed"
+else
+    log_info "AWS CLI: skipped (images already present)"
+fi
+
+# openssl installed?
+if ! command -v openssl &>/dev/null; then
+    log_error "OpenSSL is not installed. Required for certificate generation."
+    exit 1
+fi
+log_info "OpenSSL: installed"
+
+log_section "environment setup"
+
+if [ ! -f "$PROJECT_ROOT/.env" ]; then
+    log_info "Creating .env from template..."
+    cp "$PROJECT_ROOT/.env.example" "$PROJECT_ROOT/.env"
+
+    # generate encryption key
+    KEY=$(openssl rand -hex 32)
+
+    # macos vs linux sed syntax
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' "s/^ITENTIAL_ENCRYPTION_KEY=$/ITENTIAL_ENCRYPTION_KEY=$KEY/" "$PROJECT_ROOT/.env"
+    else
+        sed -i "s/^ITENTIAL_ENCRYPTION_KEY=$/ITENTIAL_ENCRYPTION_KEY=$KEY/" "$PROJECT_ROOT/.env"
+    fi
+
+    log_info "Generated encryption key"
+else
+    log_info ".env file already exists"
+
+    # is encryption key set?
+    source "$PROJECT_ROOT/.env"
+    if [ -z "$ITENTIAL_ENCRYPTION_KEY" ]; then
+        KEY=$(openssl rand -hex 32)
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i '' "s/^ITENTIAL_ENCRYPTION_KEY=$/ITENTIAL_ENCRYPTION_KEY=$KEY/" "$PROJECT_ROOT/.env"
+        else
+            sed -i "s/^ITENTIAL_ENCRYPTION_KEY=$/ITENTIAL_ENCRYPTION_KEY=$KEY/" "$PROJECT_ROOT/.env"
+        fi
+        log_info "Generated missing encryption key"
+    fi
+fi
+
+# load env
+source "$PROJECT_ROOT/.env"
+
+log_section "aws ecr authentication"
+
+ECR_REGISTRY="${ECR_REGISTRY:-497639811223.dkr.ecr.us-east-2.amazonaws.com}"
+
+if [ "$IMAGES_PRESENT" = true ]; then
+    log_info "All required images already present locally, skipping ECR authentication"
+else
+    log_info "Authenticating with AWS ECR..."
+    if aws ecr get-login-password --region us-east-2 2>/dev/null | \
+       docker login --username AWS --password-stdin "$ECR_REGISTRY" &>/dev/null; then
+        log_info "ECR authentication successful"
+    else
+        log_error "ECR authentication failed. Check your AWS credentials."
+        log_info "Run: aws configure"
+        exit 1
+    fi
+fi
+
+log_section "certificate generation"
+
+"$SCRIPT_DIR/generate-certificates.sh" --quiet
+
+log_section "file permissions"
+
+# make iag4 playbooks/scripts executable
+if [ -d "$PROJECT_ROOT/volumes/gateway4/playbooks" ]; then
+    find "$PROJECT_ROOT/volumes/gateway4/playbooks" -type f \( -name "*.yml" -o -name "*.yaml" \) \
+        -exec chmod +x {} \; 2>/dev/null || true
+    log_info "Gateway4 playbooks: permissions set"
+fi
+
+if [ -d "$PROJECT_ROOT/volumes/gateway4/scripts" ]; then
+    find "$PROJECT_ROOT/volumes/gateway4/scripts" -type f \( -name "*.py" -o -name "*.sh" \) \
+        -exec chmod +x {} \; 2>/dev/null || true
+    log_info "Gateway4 scripts: permissions set"
+fi
+
+log_section "starting services"
+
+log_info "Starting all services..."
+docker compose --profile full up -d
+
+log_section "waiting for platform"
+
+PLATFORM_URL="http://localhost:${PLATFORM_PORT:-3000}"
+MAX_WAIT=180
+WAIT_INTERVAL=5
+
+log_info "Waiting for Platform to be healthy (max ${MAX_WAIT}s)..."
+
+for ((i=0; i<MAX_WAIT; i+=WAIT_INTERVAL)); do
+    if curl -sf "${PLATFORM_URL}/health" &>/dev/null; then
+        log_info "Platform is healthy!"
+        break
+    fi
+
+    if [ $i -ge $((MAX_WAIT - WAIT_INTERVAL)) ]; then
+        log_warn "Platform health check timeout. It may still be starting."
+        log_info "Check logs with: make logs LOG=platform"
+        break
+    fi
+
+    echo -n "."
+    sleep $WAIT_INTERVAL
+done
+echo ""
+
+log_section "gateway manager configuration"
+
+if [ -f "$SCRIPT_DIR/configure-gateway-manager.sh" ]; then
+    "$SCRIPT_DIR/configure-gateway-manager.sh" || {
+        log_warn "Gateway Manager configuration skipped (Platform may not be ready)"
+        log_info "Run manually later: ./scripts/configure-gateway-manager.sh"
+    }
+else
+    log_warn "configure-gateway-manager.sh not found"
+fi
+
+log_section "setup complete"
+
+echo ""
+echo -e "${GREEN}Services are starting. Check status with: make status${NC}"
+echo ""
+echo "URLs:"
+echo "  Platform:  http://localhost:${PLATFORM_PORT:-3000}"
+echo "             Username: admin"
+echo "             Password: admin"
+echo ""
+echo "  Gateway4:  http://localhost:${GATEWAY4_PORT:-8083}"
+echo "             Username: admin@itential"
+echo "             Password: admin"
+echo ""
+echo "  Gateway5:  localhost:${GATEWAY5_PORT:-50051} (gRPC)"
+echo "             Use iagctl client to interact"
+echo ""
+echo "Common commands:"
+echo "  make up      - Start services"
+echo "  make down    - Stop services"
+echo "  make logs    - View logs"
+echo "  make status  - Check status"
+echo ""


### PR DESCRIPTION
## Summary

Add automation scripts for first-time setup and ongoing configuration:

- **setup.sh** - First-time setup orchestrator:
  - Checks Docker/Compose prerequisites
  - Generates encryption key in .env
  - Authenticates to AWS ECR (if images not cached)
  - Generates SSL certificates
  - Sets file permissions for playbooks/scripts
  - Starts services and waits for Platform health
  - Configures Gateway Manager

- **generate-certificates.sh** - SSL certificate generation:
  - Platform certs (cert.pem, key.pem)
  - Gateway5 certs (gw-manager.pem, gw-manager-key.pem)
  - Supports --force and --quiet flags

- **configure-gateway-manager.sh** - API-based Gateway Manager setup:
  - Authenticates to Platform API
  - Uploads certificates
  - Creates admin_group with all roles
  - Assigns permissions to admin user
  - Creates and enables gateway cluster
  - Includes fallback manual instructions on failure

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Testing

```bash
make setup    # Runs full setup including all scripts
make certs    # Test certificate generation independently
```

## Checklist

- [x] Code follows project style guidelines
- [x] Documentation is clear and complete
- [x] No sensitive data exposed