### PR TITLE
fix: resolve container startup failures

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,7 @@ services:
       ITENTIAL_LOG_LEVEL: ${LOG_LEVEL:-debug}
       ITENTIAL_LOG_DIRECTORY: "/var/log/itential"
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:3000/health"]
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/health"]
       interval: 30s
       timeout: 10s
       retries: 10
@@ -210,7 +210,7 @@ services:
       automation_gateway_git_enabled: "true"
       automation_gateway_vault_enabled: "false"
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:8083/api/v2.0/health"]
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:8083/"]
       interval: 15s
       timeout: 5s
       retries: 5

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -164,6 +164,26 @@ if [ -d "$PROJECT_ROOT/volumes/gateway4/scripts" ]; then
     log_info "Gateway4 scripts: permissions set"
 fi
 
+# set volume ownership to match container UIDs
+# platform and gateway4 run as UID 1001, gateway5 runs as UID 100
+PLATFORM_DIRS=("$PROJECT_ROOT/volumes/platform/logs" "$PROJECT_ROOT/volumes/platform/adapters")
+GATEWAY4_DIRS=("$PROJECT_ROOT/volumes/gateway4/data" "$PROJECT_ROOT/volumes/gateway4/scripts" "$PROJECT_ROOT/volumes/gateway4/playbooks" "$PROJECT_ROOT/volumes/gateway4/terraform")
+GATEWAY5_DIRS=("$PROJECT_ROOT/volumes/gateway5/data")
+
+if command -v sudo &>/dev/null; then
+    for dir in "${PLATFORM_DIRS[@]}" "${GATEWAY4_DIRS[@]}"; do
+        [ -d "$dir" ] && sudo chown -R 1001:1001 "$dir" 2>/dev/null || true
+    done
+    log_info "Platform/Gateway4 volumes: ownership set (UID 1001)"
+
+    for dir in "${GATEWAY5_DIRS[@]}"; do
+        [ -d "$dir" ] && sudo chown -R 100:101 "$dir" 2>/dev/null || true
+    done
+    log_info "Gateway5 volumes: ownership set (UID 100)"
+else
+    log_warn "sudo not available, skipping volume ownership (may cause permission issues)"
+fi
+
 log_section "starting services"
 
 log_info "Starting all services..."


### PR DESCRIPTION
## Description

Fixes container startup failures caused by volume permission mismatches and missing health check binaries.

## Type of Change

- [x] Bug fix

## Changes Made

- Add volume ownership setup in `setup.sh` to match container UIDs (1001 for platform/gateway4, 100 for gateway5)
- Replace `curl` with `wget` in health checks (curl not available in containers)
- Use unauthenticated endpoint for gateway4 health check

## Testing

Run `make clean && make setup` and verify all containers show healthy status with `docker ps`.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed