### PR TITLE
docs: add PR labeling requirement to guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,3 +29,4 @@
 - [ ] Commits follow conventional format (`type: subject`)
 - [ ] No secrets or credentials committed
 - [ ] Documentation has been updated accordingly
+- [ ] PR has been labeled appropriately (`enhancement`, `bug`, `documentation`, `refactor`, `chore`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,18 @@ git push origin feature/your-feature-name
 2. Click **Compare & pull request**
 3. Target the `main` branch of the upstream repository
 4. Fill out the PR template
-5. Submit the pull request
+5. Add a label matching your change type (see table below)
+6. Submit the pull request
+
+**PR labels:**
+
+| Commit Type | Label |
+|-------------|-------|
+| `feat`      | `enhancement` |
+| `fix`       | `bug` |
+| `docs`      | `documentation` |
+| `refactor`  | `refactor` |
+| `chore`     | `chore` |
 
 ### 9. Address Review Feedback
 
@@ -164,6 +175,7 @@ Before submitting:
 - [ ] Commits follow conventional format (`type: subject`)
 - [ ] No secrets or credentials committed
 - [ ] Documentation has been updated accordingly
+- [ ] PR has been labeled appropriately
 
 ## Getting Help
 


### PR DESCRIPTION
## Description

Adds PR labeling as a required step in the contribution workflow and PR checklist.

## Type of Change

- [x] Documentation

## Changes Made

- Added label mapping table to CONTRIBUTING.md section 8 (Open a Pull Request)
- Added "PR has been labeled appropriately" checkbox to both checklists
- Labels: `enhancement`, `bug`, `documentation`, `refactor`, `chore`

## Testing

Review the updated documentation in CONTRIBUTING.md and .github/PULL_REQUEST_TEMPLATE.md.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed