### PR TITLE
fix: use dynamic UID/GID in gateway4-init container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,7 +162,10 @@ services:
     volumes:
       - gateway4-data:/mnt/data
       - gateway4-app:/mnt/app
-    command: sh -c "chown -R 1000:1000 /mnt/data /mnt/app && chmod -R 755 /mnt/data /mnt/app"
+    environment:
+      - UID=${UID:-1000}
+      - GID=${GID:-1000}
+    command: sh -c "chown -R ${UID:-1000}:${GID:-1000} /mnt/data /mnt/app && chmod -R 755 /mnt/data /mnt/app"
     restart: "no"
 
   gateway4:


### PR DESCRIPTION
## Description

Fixes Gateway4 restart loop on macOS by using dynamic UID/GID values in the gateway4-init container instead of hardcoded 1000:1000. The init container now matches the main gateway4 container's approach of using environment variables from Makefile auto-detection.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added environment variables to gateway4-init service (UID and GID)
- Updated chown command to use ${UID:-1000}:${GID:-1000} instead of hardcoded 1000:1000
- Ensures volume ownership matches container user on both macOS (501:20) and Linux (1000:1000)

## Testing

Run `make clean && make setup` on macOS and verify Gateway4 starts without restart loop:
```bash
docker ps --filter name=gateway4  # Should show "Up" and "healthy"
docker logs gateway4              # Should show no permission errors
```

Verify volume ownership matches host UID:
```bash
docker run --rm -v itential-dev-stack_gateway4-data:/mnt alpine ls -ldn /mnt
# Should show 501:20 on macOS, 1000:1000 on Linux
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Tested with `make setup` on macOS
- [x] Commits follow conventional format
- [x] No secrets or credentials committed
- [x] Maintains backward compatibility with Linux