### PR TITLE
docs: add code of conduct and update license

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,56 @@
+# Open Source Code of Conduct
+
+## Purpose
+
+This Code of Conduct sets expectations for behavior in our open source community. It ensures a respectful, safe, and inclusive environment for contributors, maintainers, users, and newcomers—regardless of background, skill level, or personal identity.
+
+Open source thrives when everyone can contribute without harassment, discrimination, or toxicity. If you're here to collaborate, you're expected to follow this.
+
+## Expected Behavior
+
+We expect all contributors to:
+
+- **Be respectful**: Value different perspectives. Disagree without personal attacks.
+- **Be constructive**: Critique code and ideas, not people. If something’s broken, propose a fix.
+- **Be inclusive**: Welcome beginners, mentor others, and use inclusive language.
+- **Take responsibility**: Own your mistakes, learn from feedback, and help improve the project.
+- **Communicate clearly**: Write good issues, PRs, and commit messages. Default to transparency.
+
+## Unacceptable Behavior
+
+These are **not tolerated**:
+
+- Hate speech, slurs, or discriminatory jokes.
+- Harassment, intimidation, or sustained disruption.
+- Doxxing or sharing private information without consent.
+- Trolling, flame wars, or intentionally derailing conversations.
+- “Gatekeeping” or belittling others based on experience, tools, or tech stack.
+
+## Enforcement
+
+Violations will be handled promptly and decisively:
+
+- Minor incidents may result in a warning.
+- Repeated or severe behavior can lead to bans from the project (GitHub issues, PRs, Slack/Discord, etc.).
+- Reports will be reviewed by the maintainers or a designated moderation team.
+
+## Reporting
+
+If you experience or witness a violation, **speak up**:
+
+- Email: opensource@itential.com
+- Or DM a maintainer in private on our official chat
+
+All reports are confidential. Retaliation against reporters **will not be tolerated**.
+
+## Scope
+
+This Code of Conduct applies in all project spaces, including:
+
+- GitHub issues and PRs
+- Community forums, chats, and meetings
+- Social media when representing the project
+
+## Attribution
+
+This code is based on the [Contributor Covenant](https://www.contributor-covenant.org), with pragmatic additions tailored for modern open source development.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,3 @@
-itential-dev-stack - Local development environment for Itential Platform
-Copyright (C) 2025 Itential
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
-
--------------------------------------------------------------------------------
-
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
@@ -670,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    <program>  Copyright (C) <year>  <name of author>
+    itential-dev-stack  Copyright (C) 2025  Itential, LLC
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.


### PR DESCRIPTION
## Description

Adds a Code of Conduct for the open source community and updates the LICENSE file to use clean GPL v3 formatting with project-specific copyright.

## Type of Change

- [x] Documentation update

## Changes Made

- Add CODE_OF_CONDUCT.md with community guidelines and reporting contact
- Update LICENSE to use standard GPL v3 format with Itential copyright

## Testing

Documentation-only changes, no functional testing required.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed