### PR TITLE
feat: enable LDAP and MCP by default in setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,17 +27,17 @@ GATEWAY5_CLUSTER_ID=cluster_1
 # UID=1000
 # GID=1000
 
-# === LDAP (optional - set LDAP_ENABLED=true to auto-start with make setup/up) ===
-# LDAP_ENABLED=true
+# === LDAP (auto-starts with make setup/up, set to false to disable) ===
+LDAP_ENABLED=true
 # LDAP_PORT=3389
 # LDAP_ADMIN_PASSWORD=admin
 
-# === MCP (optional - set MCP_ENABLED=true to auto-start with make setup/up) ===
-# MCP_ENABLED=true
+# === MCP (auto-starts with make setup/up, set to false to disable) ===
+MCP_ENABLED=true
 # MCP_TRANSPORT=stdio
 # MCP_SSE_PORT=8000
-# MCP_PLATFORM_USER=admin
-# MCP_PLATFORM_PASSWORD=admin
+MCP_PLATFORM_USER=admin@itential
+MCP_PLATFORM_PASSWORD=admin
 
 # === OPENBAO (optional - set OPENBAO_ENABLED=true to auto-start with make setup/up) ===
 # OpenBao is a Vault-compatible secrets management solution with persistent storage


### PR DESCRIPTION
## Description

Enable LDAP and MCP services by default when running `make setup`. MCP is configured to use the LDAP user `admin@itential` for Platform authentication.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Enable `LDAP_ENABLED=true` by default in `.env.example`
- Enable `MCP_ENABLED=true` by default in `.env.example`
- Set `MCP_PLATFORM_USER=admin@itential` (LDAP user)
- Set `MCP_PLATFORM_PASSWORD=admin`
- Update section comments to reflect new defaults

## Testing

1. Remove existing `.env` file
2. Run `make setup`
3. Verify LDAP and MCP services start automatically
4. Verify MCP connects to Platform using LDAP credentials

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed