### PR TITLE
feat: default Platform to HTTPS, make HTTP optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,8 @@ GATEWAY5_CLUSTER_ID=cluster_1
 
 # === OPTIONAL OVERRIDES ===
 # LOG_LEVEL=debug
-# PLATFORM_PORT=3000
+# PLATFORM_PORT=3000           # HTTP port (disabled by default, uncomment in docker-compose.yml to enable)
+# PLATFORM_HTTPS_PORT=3443     # HTTPS port (default)
 # GATEWAY4_PORT=8083
 # GATEWAY5_PORT=50051
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ GID ?= $(shell id -g)
 
 # default values
 PLATFORM_PORT ?= 3000
+PLATFORM_HTTPS_PORT ?= 3443
 GATEWAY4_PORT ?= 8083
 LDAP_PORT ?= 3389
 MCP_SSE_PORT ?= 8000
@@ -61,7 +62,13 @@ status: ## Show service status and URLs
 	@docker compose --profile full --profile ldap --profile mcp --profile openbao ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}"
 	@echo ""
 	@echo "URLs:"
-	@echo "  Platform:  http://localhost:$(PLATFORM_PORT)  (admin/admin)"
+	@if grep -qE '^\s+- "\$${BIND_ADDRESS}\$${PLATFORM_PORT' docker-compose.yml; then \
+		echo "  Platform:  http://localhost:$(PLATFORM_PORT)  (admin/admin)"; \
+	elif grep -qE '^\s+- "\$${BIND_ADDRESS}\$${PLATFORM_HTTPS_PORT' docker-compose.yml; then \
+		echo "  Platform:  https://localhost:$(PLATFORM_HTTPS_PORT)  (admin/admin)"; \
+	else \
+		echo "  Platform:  https://localhost:$(PLATFORM_HTTPS_PORT)  (admin/admin)"; \
+	fi
 	@echo "  Gateway4:  http://localhost:$(GATEWAY4_PORT)  (admin@itential/admin)"
 	@if docker ps --format '{{.Names}}' | grep -q '^openldap$$'; then \
 		echo "  OpenLDAP:  localhost:$(LDAP_PORT)  (cn=admin,dc=itential,dc=io/admin)"; \

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ REDIS_VERSION=7.4
 
 ```bash
 # Ports (if defaults conflict)
-PLATFORM_PORT=3000
+PLATFORM_HTTPS_PORT=3443
+PLATFORM_PORT=3000          # HTTP disabled by default (uncomment in docker-compose.yml to enable)
 GATEWAY4_PORT=8083
 GATEWAY5_PORT=50051
 
@@ -124,7 +125,7 @@ PLATFORM_INIT_DELAY=15
 
 | Service | URL | Credentials |
 |---------|-----|-------------|
-| Platform | http://localhost:3000 | admin / admin |
+| Platform | https://localhost:3443 | admin / admin |
 | Gateway4 | http://localhost:8083 | admin@itential / admin |
 | Gateway5 | localhost:50051 (gRPC) | Use `iagctl` client |
 | OpenLDAP | localhost:3389 | cn=admin,dc=itential,dc=io / admin |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,7 +120,8 @@ services:
       platform-init:
         condition: service_completed_successfully
     ports:
-      - "${BIND_ADDRESS}${PLATFORM_PORT:-3000}:3000"
+      # - "${BIND_ADDRESS}${PLATFORM_PORT:-3000}:3000"  # Uncomment to enable HTTP
+      - "${BIND_ADDRESS}${PLATFORM_HTTPS_PORT:-3443}:3443"
       - "${BIND_ADDRESS}8080:8080"
     volumes:
       - type: bind
@@ -154,7 +155,9 @@ services:
 
       # web server
       ITENTIAL_WEBSERVER_HTTP_PORT: 3000
+      ITENTIAL_WEBSERVER_HTTP_ENABLED: "false"
       ITENTIAL_WEBSERVER_HTTPS_PORT: 3443
+      ITENTIAL_WEBSERVER_HTTPS_ENABLED: "true"
       ITENTIAL_WEBSERVER_HTTPS_KEY: "/etc/ssl/platform/key.pem"
       ITENTIAL_WEBSERVER_HTTPS_CERT: "/etc/ssl/platform/cert.pem"
 
@@ -163,7 +166,7 @@ services:
       ITENTIAL_LOG_DIRECTORY: "/var/log/itential"
 
     healthcheck:
-      test: ["CMD-SHELL", "wget -q --spider http://localhost:3000/login 2>/dev/null || curl -sf http://localhost:3000/login >/dev/null"]
+      test: ["CMD-SHELL", "(wget -q --spider --no-check-certificate https://localhost:3443/login 2>/dev/null || curl -sfk https://localhost:3443/login >/dev/null) || (wget -q --spider http://localhost:3000/login 2>/dev/null || curl -sf http://localhost:3000/login >/dev/null)"]
       interval: 30s
       timeout: 10s
       retries: 10

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -279,7 +279,13 @@ echo ""
 echo -e "${GREEN}Services are starting. Check status with: make status${NC}"
 echo ""
 echo "URLs:"
-echo "  Platform:  http://localhost:${PLATFORM_PORT:-3000}"
+if grep -qE '^\s+- "\$\{BIND_ADDRESS\}\$\{PLATFORM_PORT' "$PROJECT_ROOT/docker-compose.yml"; then
+    echo "  Platform:  http://localhost:${PLATFORM_PORT:-3000}"
+elif grep -qE '^\s+- "\$\{BIND_ADDRESS\}\$\{PLATFORM_HTTPS_PORT' "$PROJECT_ROOT/docker-compose.yml"; then
+    echo "  Platform:  https://localhost:${PLATFORM_HTTPS_PORT:-3443}"
+else
+    echo "  Platform:  https://localhost:${PLATFORM_HTTPS_PORT:-3443}"
+fi
 echo "             Username: admin"
 echo "             Password: admin"
 echo ""


### PR DESCRIPTION
- Expose port 3443 (HTTPS) by default instead of 3000 (HTTP)
- Update healthcheck to try HTTPS first, fall back to HTTP
- Make status commands detect and display correct protocol
- HTTP can be re-enabled by uncommenting port mapping and setting ITENTIAL_WEBSERVER_HTTP_ENABLED=true

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

## Changes Made

<!-- Summarize the key changes in this PR -->

## Testing

<!-- Describe how you tested your changes -->

## Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code has been performed
- [ ] Code has been commented where necessary
- [ ] Tested with `make setup` or relevant profile
- [ ] Commits follow conventional format (`type: subject`)
- [ ] No secrets or credentials committed
- [ ] Documentation has been updated accordingly
- [ ] PR has been labeled appropriately (`enhancement`, `bug`, `documentation`, `refactor`, `chore`)
