### PR TITLE
feat: configurable stack profiles, gateway enable flags, and port variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,19 +5,38 @@
 # 64-character hex encryption key (generate with: make generate-key)
 ITENTIAL_ENCRYPTION_KEY=
 
+# === STACK PROFILE ===
+# Controls which base services "make setup" and "make up" start.
+# Use enable flags below to add individual services on top of the base profile.
+#   full     = MongoDB, Redis, Platform, Gateway4, Gateway5 (default)
+#   platform = MongoDB, Redis, Platform
+#   deps     = MongoDB, Redis only
+# STACK_PROFILE=full
+
+# === GATEWAYS ===
+# Enable gateways independently (useful with STACK_PROFILE=platform)
+# GATEWAY4_ENABLED=true
+# GATEWAY5_ENABLED=true
+
 # === IMAGES ===
 # Full image URLs for Itential services (supports any registry)
-# Default values are defined in defaults.env - uncomment below to override
+# Default values (AWS ECR) are defined in defaults.env - uncomment below to override
+#
+# AWS ECR (default):
 # PLATFORM_IMAGE=497639811223.dkr.ecr.us-east-2.amazonaws.com/automation-platform-config-lcm:6
 # GATEWAY4_IMAGE=497639811223.dkr.ecr.us-east-2.amazonaws.com/automation-gateway:4.3.7
 # GATEWAY5_IMAGE=497639811223.dkr.ecr.us-east-2.amazonaws.com/automation-gateway5:5.1.0-amd64
+#
+# JFrog (requires: docker login itential.jfrog.io):
+# PLATFORM_IMAGE=itential.jfrog.io/flowai/itential_flowai:v0.0.6
+# GATEWAY5_IMAGE=itential.jfrog.io/flowai/itential_flowai_gateway5:5.3.0-amd64
 
 # Dependency versions (from public registries, defaults in defaults.env)
 # MONGO_VERSION=8.0
 # REDIS_VERSION=7.4
 
 # === GATEWAY MANAGER ===
-GATEWAY5_CLUSTER_ID=cluster_1
+# GATEWAY5_CLUSTER_ID=cluster_1
 
 # === NETWORK BINDING ===
 # Controls which network interfaces services bind to
@@ -25,11 +44,20 @@ GATEWAY5_CLUSTER_ID=cluster_1
 # "127.0.0.1:" = localhost only (more secure for local development)
 # BIND_ADDRESS=127.0.0.1:
 
-# === OPTIONAL OVERRIDES ===
-# LOG_LEVEL=debug
+# === PORTS ===
+# Override if defaults conflict with existing services on your machine
 # PLATFORM_PORT=3000
+# GATEWAY_MANAGER_PORT=8080
+# MONGO_PORT=27017
+# REDIS_PORT=6379
 # GATEWAY4_PORT=8083
 # GATEWAY5_PORT=50051
+# LDAP_PORT=3389
+# MCP_SSE_PORT=8000
+# OPENBAO_PORT=8200
+
+# === OPTIONAL OVERRIDES ===
+# LOG_LEVEL=debug
 
 # === USER/GROUP IDS ===
 # Override if using alternative images with different UIDs
@@ -41,20 +69,20 @@ GATEWAY5_CLUSTER_ID=cluster_1
 # UID=1000
 # GID=1000
 
-# === LDAP (auto-starts with make setup/up, set to false to disable) ===
+# === LDAP (enabled by default for UI login experience) ===
 LDAP_ENABLED=true
 # LDAP_PORT=3389
 # LDAP_ADMIN_PASSWORD=admin
 
-# === MCP (auto-starts with make setup/up, set to false to disable) ===
-MCP_ENABLED=true
+# === MCP (set to true to enable) ===
+# MCP_ENABLED=true
 # MCP_VERSION=v0.10.0
 # MCP_TRANSPORT=sse  # default is sse; use stdio for CLI tools
 # MCP_SSE_PORT=8000
-MCP_PLATFORM_USER=admin@itential
-MCP_PLATFORM_PASSWORD=admin
+# MCP_PLATFORM_USER=admin@itential
+# MCP_PLATFORM_PASSWORD=admin
 
-# === OPENBAO (optional - set OPENBAO_ENABLED=true to auto-start with make setup/up) ===
+# === OPENBAO (set to true to enable) ===
 # OpenBao is a Vault-compatible secrets management solution with persistent storage
 # When enabled, Platform is automatically configured to use OpenBao
 # Root token is generated on first run and saved to volumes/openbao/init-keys.json

--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,24 @@ GID ?= $(shell id -g)
 
 # default values
 PLATFORM_PORT ?= 3000
+GATEWAY_MANAGER_PORT ?= 8080
+MONGO_PORT ?= 27017
+REDIS_PORT ?= 6379
 GATEWAY4_PORT ?= 8083
+GATEWAY5_PORT ?= 50051
 LDAP_PORT ?= 3389
 MCP_SSE_PORT ?= 8000
 OPENBAO_PORT ?= 8200
 
 # build profile list based on enabled services
-PROFILES := --profile full
+STACK_PROFILE ?= full
+PROFILES := --profile $(STACK_PROFILE)
+ifeq ($(GATEWAY4_ENABLED),true)
+  PROFILES += --profile gateway4
+endif
+ifeq ($(GATEWAY5_ENABLED),true)
+  PROFILES += --profile gateway5
+endif
 ifeq ($(LDAP_ENABLED),true)
   PROFILES += --profile ldap
 endif

--- a/README.md
+++ b/README.md
@@ -1,222 +1,300 @@
-# 🔬 Itential - Local Development Stack
+# Itential - Local Development Stack
 
-A local development environment for [Itential Platform](https://www.itential.com/cloud-platform/overview/) and other related technologies.
+A local development environment for [Itential Platform](https://www.itential.com/cloud-platform/overview/) and related technologies.
 
 > **Note**: This environment is for development and testing only. Do not use in production.
 
-## ⏰ Quick Start
+## Getting Started
+
+### 1. Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) (v20.10+) with [Docker Compose](https://docs.docker.com/compose/install/) (v2.0+)
+- Access to an image registry — either **AWS ECR** or **JFrog** (see [Image Registries](#image-registries))
+
+### 2. Configure your environment
 
 ```bash
-# First-time setup (generates key, certs, starts services, connects IAG to Gateway Manager)
-make setup
+cp .env.example .env    # make setup also does this if .env doesn't exist
+```
 
-# Daily usage
-make up       # Start all services
-make down     # Stop all services
-make logs     # View logs
+Open `.env` and configure:
+
+**Choose what to run** — pick a base profile and enable the services you need:
+
+```bash
+# Base profile: full | platform | deps
+#   full     = MongoDB, Redis, Platform, Gateway4, Gateway5
+#   platform = MongoDB, Redis, Platform (most common)
+#   deps     = MongoDB, Redis only
+STACK_PROFILE=platform
+
+# Enable individual services on top of the base profile
+GATEWAY5_ENABLED=true
+LDAP_ENABLED=true
+# MCP_ENABLED=true
+# OPENBAO_ENABLED=true
+```
+
+**Choose your image registry** — uncomment one set:
+
+```bash
+# AWS ECR (default — requires: make login)
+PLATFORM_IMAGE=497639811223.dkr.ecr.us-east-2.amazonaws.com/automation-platform-config-lcm:6
+GATEWAY5_IMAGE=497639811223.dkr.ecr.us-east-2.amazonaws.com/automation-gateway5:5.1.0-amd64
+
+# JFrog (requires: docker login itential.jfrog.io)
+PLATFORM_IMAGE=itential.jfrog.io/flowai/itential_flowai:v0.0.6
+GATEWAY5_IMAGE=itential.jfrog.io/flowai/itential_flowai_gateway5:5.3.0-amd64
+```
+
+### 3. Run setup
+
+```bash
+make setup
+```
+
+This generates an encryption key, creates SSL certificates, starts your services, and configures Gateway Manager and any enabled optional services.
+
+### 4. Daily usage
+
+```bash
+make up       # Start services
+make down     # Stop services
+make logs     # View logs (or: make logs LOG=platform)
 make status   # Check status and URLs
 ```
 
-## ✅ Prerequisites
+## Stack Profiles
 
-**Container Runtime** (one of the following):
-- [Docker](https://docs.docker.com/get-docker/) (v20.10+) with [Docker Compose](https://docs.docker.com/compose/install/) (v2.0+)
-- [Podman](https://podman.io/docs/installation) (v4.0+) with [Podman Compose](https://github.com/containers/podman-compose) — see [Using Podman](#using-podman)
+The profile system has two layers that let you run exactly what you need:
 
-**Other Requirements:**
-- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) configured with Itential ECR access (only required if images need to be pulled)
+**Base profile** (`STACK_PROFILE`) determines the core services:
 
-### AWS ECR Access
+| Profile | Services | Use Case |
+|---------|----------|----------|
+| `full` | MongoDB, Redis, Platform, Gateway4, Gateway5 | Complete stack |
+| `platform` | MongoDB, Redis, Platform | Platform development (most common) |
+| `deps` | MongoDB, Redis | Dependencies only |
 
-Before first use, ensure you have access to Itential's AWS ECR repository. See [Repository Access](https://docs.itential.com/docs/running-containers-itential-platform#docker-repository-access).
+**Enable flags** add individual services on top of the base profile:
 
-> **Note**: If all required Itential images are already present locally, `make setup` will skip AWS CLI and ECR authentication automatically.
+| Variable | Service |
+|----------|---------|
+| `GATEWAY4_ENABLED=true` | Automation Gateway 4 |
+| `GATEWAY5_ENABLED=true` | Automation Gateway 5 |
+| `LDAP_ENABLED=true` | OpenLDAP |
+| `MCP_ENABLED=true` | MCP Server (LLM integration) |
+| `OPENBAO_ENABLED=true` | OpenBao (secrets management) |
 
-## 🫛 Using Podman
-
-This project is OCI-compliant and works with Podman _(and other container runtimes)_. The scripts and Makefile reference `docker` commands directly, so choose one of these approaches:
-
-### Option 1: Docker CLI Emulation (Recommended)
-
-Install the compatibility package that creates a `docker` symlink:
-
-```bash
-# Fedora/RHEL/CentOS
-sudo dnf install podman-docker
-
-# Ubuntu/Debian
-sudo apt install podman-docker
-```
-
-With this installed, all `make` commands and scripts work unchanged.
-
-### Option 2: Manual Command Substitution
-
-Replace `docker` with `podman` and `docker compose` with `podman-compose`:
+### Examples
 
 ```bash
-# Instead of: make up
-podman-compose --profile full up -d
+# Platform + Gateway5 + LDAP (no Gateway4)
+STACK_PROFILE=platform
+GATEWAY5_ENABLED=true
+LDAP_ENABLED=true
 
-# Instead of: make down
-podman-compose --profile full down
+# Full stack (everything)
+STACK_PROFILE=full
 
-# Instead of: make logs
-podman-compose --profile full logs -f
+# Platform only (minimal)
+STACK_PROFILE=platform
 ```
 
-### ECR Authentication with Podman
+Both `make setup` and `make up` respect these settings automatically.
 
-```bash
-aws ecr get-login-password --region us-east-2 | \
-  podman login --username AWS --password-stdin 497639811223.dkr.ecr.us-east-2.amazonaws.com
-```
+## Services
 
-### Known Considerations
-
-- **Rootless mode**: Works with proper volume permissions (containers run as your user ID)
-- **podman-compose**: Feature parity with Docker Compose v2 is good but verify version 1.0.6+
-- **Compose profiles**: Fully supported in podman-compose 1.0.6+
-- **Health checks**: Work identically to Docker
-
-## 💻 Configuration
-
-Configuration is managed via `.env` file. On first run, `make setup` creates this from `.env.example`.
-
-### Essential Variables
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `ITENTIAL_ENCRYPTION_KEY` | 64-char hex encryption key (auto-generated) | Required |
-| `GATEWAY5_CLUSTER_ID` | Gateway Manager cluster identifier | `cluster_1` |
-
-### Image Configuration
-
-Image defaults are defined in `defaults.env` (version-controlled, single source of truth). To override, uncomment and modify in your `.env` file:
-
-```bash
-# Itential images - full URLs (supports any registry)
-PLATFORM_IMAGE=497639811223.dkr.ecr.us-east-2.amazonaws.com/automation-platform-config-lcm:6
-GATEWAY4_IMAGE=497639811223.dkr.ecr.us-east-2.amazonaws.com/automation-gateway:4.3.7
-GATEWAY5_IMAGE=497639811223.dkr.ecr.us-east-2.amazonaws.com/automation-gateway5:5.1.0-amd64
-
-# Dependency versions
-MONGO_VERSION=8.0
-REDIS_VERSION=7.4
-```
-
-### Optional Overrides
-
-```bash
-# Ports (if defaults conflict)
-PLATFORM_PORT=3000
-GATEWAY4_PORT=8083
-GATEWAY5_PORT=50051
-
-# Logging
-LOG_LEVEL=debug
-
-# Gateway Manager timing (seconds to wait after Platform API responds)
-PLATFORM_INIT_DELAY=15
-```
-
-## 📋 Services
-
-| Service | URL | Credentials |
-|---------|-----|-------------|
+| Service | Default URL | Credentials |
+|---------|-------------|-------------|
 | Platform | http://localhost:3000 | admin / admin |
 | Gateway4 | http://localhost:8083 | admin@itential / admin |
 | Gateway5 | localhost:50051 (gRPC) | Use `iagctl` client |
+| MongoDB | localhost:27017 | N/A |
+| Redis | localhost:6379 | N/A |
 | OpenLDAP | localhost:3389 | cn=admin,dc=itential,dc=io / admin |
 | MCP | http://localhost:8000 (SSE) | N/A |
 | OpenBao | http://localhost:8200 | Token from `volumes/openbao/init-keys.json` |
-| MongoDB | localhost:27017 | N/A |
-| Redis | localhost:6379 | N/A |
 
-## 🔍 Docker Compose Profiles
+> All ports are configurable via `.env` — see [Port Configuration](#port-configuration).
 
-Start specific service combinations:
+## Configuration Reference
+
+All configuration is managed via `.env` (see [Getting Started](#2-configure-your-environment)).
+
+The configuration loads in two layers:
+1. **`defaults.env`** — Version-controlled defaults (ECR images, dependency versions). Do not edit.
+2. **`.env`** — Your overrides (git-ignored). Any variable set here takes precedence.
+
+> Always use `make` commands (`make up`, `make down`, etc.) to ensure both files are loaded correctly.
+
+### Image Registries
+
+Image defaults are in `defaults.env` (version-controlled) and point to AWS ECR. Override in your `.env`:
+
+**AWS ECR** (default):
+```bash
+# Requires: make login (or AWS CLI configured with ECR access)
+PLATFORM_IMAGE=497639811223.dkr.ecr.us-east-2.amazonaws.com/automation-platform-config-lcm:6
+GATEWAY4_IMAGE=497639811223.dkr.ecr.us-east-2.amazonaws.com/automation-gateway:4.3.7
+GATEWAY5_IMAGE=497639811223.dkr.ecr.us-east-2.amazonaws.com/automation-gateway5:5.1.0-amd64
+```
+
+**JFrog**:
+```bash
+# Requires: docker login itential.jfrog.io
+PLATFORM_IMAGE=itential.jfrog.io/flowai/itential_flowai:v0.0.6
+GATEWAY5_IMAGE=itential.jfrog.io/flowai/itential_flowai_gateway5:5.3.0-amd64
+```
+
+> When using non-ECR images, `make setup` automatically skips AWS authentication.
+
+### Port Configuration
+
+Override in `.env` if defaults conflict with existing services on your machine:
+
+| Variable | Service | Default |
+|----------|---------|---------|
+| `PLATFORM_PORT` | Platform UI | `3000` |
+| `GATEWAY_MANAGER_PORT` | Gateway Manager API | `8080` |
+| `MONGO_PORT` | MongoDB | `27017` |
+| `REDIS_PORT` | Redis | `6379` |
+| `GATEWAY4_PORT` | Automation Gateway 4 | `8083` |
+| `GATEWAY5_PORT` | Automation Gateway 5 (gRPC) | `50051` |
+| `LDAP_PORT` | OpenLDAP | `3389` |
+| `MCP_SSE_PORT` | MCP Server | `8000` |
+| `OPENBAO_PORT` | OpenBao | `8200` |
+
+### Platform UID/GID
+
+Different platform images may run as different UIDs. The init container sets log directory ownership based on these variables:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `PLATFORM_UID` | Platform container user ID | `1001` |
+| `PLATFORM_GID` | Platform container group ID | `1001` |
+
+> The standard ECR image uses UID `1001`. JFrog flowai images use UID `1000`. To check an image: `docker inspect <image> --format '{{.Config.User}}'`
+
+### Other Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ITENTIAL_ENCRYPTION_KEY` | 64-char hex encryption key | Auto-generated |
+| `GATEWAY5_CLUSTER_ID` | Gateway Manager cluster ID | `cluster_1` |
+| `LOG_LEVEL` | Application log level | `debug` |
+| `BIND_ADDRESS` | Network binding (`""` = all, `"127.0.0.1:"` = localhost) | `""` |
+
+## Make Commands
+
+| Command | Description |
+|---------|-------------|
+| `make setup` | First-time setup (key, certs, start, configure) |
+| `make up` | Start services |
+| `make down` | Stop services |
+| `make logs` | Follow all logs (or: `make logs LOG=platform`) |
+| `make status` | Show status and URLs |
+| `make certs` | Generate SSL certificates |
+| `make login` | Login to AWS ECR |
+| `make clean` | Stop and remove all data (destructive) |
+| `make generate-key` | Generate new encryption key |
+
+## LDAP Authentication
+
+OpenLDAP provides enterprise LDAP authentication testing.
+
+**Enable**: Set `LDAP_ENABLED=true` in `.env`, then `make setup`.
+
+After setup, log in with any pre-configured user:
+
+| User | Password | Access |
+|------|----------|--------|
+| admin@itential | admin | Full admin (all roles + Gateway Manager) |
+| builder@itential | builder | LDAP group: builders |
+| operator@itential | operator | LDAP group: operators |
+
+<details>
+<summary>LDAP connection details</summary>
+
+| Property | Value |
+|----------|-------|
+| Host (from containers) | openldap |
+| Host (from host) | localhost |
+| Port | 389 (container) / 3389 (host) |
+| Admin DN | cn=admin,dc=itential,dc=io |
+| Admin Password | admin |
+| Base DN | dc=itential,dc=io |
+
+For advanced configuration, see the [official documentation](https://docs.itential.com/docs/configuring-open-ldap-iap).
+</details>
+
+## MCP Server (LLM Integration)
+
+The [MCP](https://github.com/itential/itential-mcp) server enables LLM tools (Claude Code, Claude Desktop) to interact with Itential Platform.
+
+**Enable**: Set `MCP_ENABLED=true` in `.env`, then `make setup` or `make up`.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `MCP_TRANSPORT` | Transport mode: `sse` or `stdio` | `sse` |
+| `MCP_PLATFORM_USER` | Platform username | `admin` |
+| `MCP_PLATFORM_PASSWORD` | Platform password | `admin` |
+
+See [docs/itential-mcp](docs/itential-mcp/) for Claude Desktop configuration examples.
+
+## OpenBao (Secrets Management)
+
+[OpenBao](https://openbao.org/) provides Vault-compatible secrets management.
+
+**Enable**: Set `OPENBAO_ENABLED=true` in `.env`, then `make setup`.
+
+Setup automatically initializes OpenBao, saves the root token, enables KV v2, configures Platform integration, and installs the Vault adapter.
 
 ```bash
-# All services (default)
-docker compose --profile full up -d
+# Get your root token after setup
+cat volumes/openbao/init-keys.json | jq -r '.root_token'
 
-# Platform + dependencies only (most common for development)
-docker compose --profile platform up -d
-
-# Dependencies only (MongoDB + Redis)
-docker compose --profile deps up -d
-
-# Add Gateway4 to running stack
-docker compose --profile gateway4 up -d
-
-# Add Gateway5 to running stack
-docker compose --profile gateway5 up -d
-
-# Platform with LDAP (for enterprise auth testing)
-docker compose --profile platform --profile ldap up -d
-
-# Platform with MCP (for LLM integration)
-docker compose --profile platform --profile mcp up -d
-
-# Full stack with OpenBao (for secrets management)
-docker compose --profile full --profile openbao up -d
+# Access the UI
+open http://localhost:8200
 ```
 
-## 🪾 File Structure
-
-```
-itential-dev-stack/
-├── docker-compose.yml      # Unified compose configuration
-├── .env                    # Your configuration (git-ignored)
-├── .env.example            # Configuration template
-├── defaults.env            # Default values (version-controlled)
-├── Makefile                # Common commands
-├── scripts/
-│   ├── setup.sh            # First-time setup
-│   ├── generate-certificates.sh
-│   └── configure-gateway-manager.sh
-├── docs/                   # Usage documentation
-│   └── README.md           # Client configuration examples
-├── volumes/
-│   ├── platform/
-│   │   ├── adapters/       # Custom adapters
-│   │   └── ssl/            # SSL certificates
-│   │   # Note: Platform logs use a named Docker volume (platform-logs)
-│   ├── gateway4/
-│   │   ├── data/           # SQLite databases
-│   │   ├── playbooks/      # Ansible playbooks
-│   │   ├── scripts/        # Python scripts
-│   │   └── ssl/            # SSL certificates
-│   ├── gateway5/
-│   │   ├── certificates/   # Gateway Manager certs
-│   │   └── scripts/        # Custom scripts
-│   │   # Note: Gateway5 database uses a named Docker volume (gateway5-data)
-│   ├── ldap/
-│   │   └── openldap.ldif   # LDAP users & groups
-│   ├── mcp/
-│   │   └── logs/           # MCP server logs
-│   └── openbao/            # OpenBao configuration (optional)
-└── dependencies/
-    └── mongodb-data/       # MongoDB persistent data
-```
-
-## 🍚 Make Commands
+<details>
+<summary>Working with secrets</summary>
 
 ```bash
-make help           # Show all commands
-make setup          # First-time setup
-make up             # Start all services
-make down           # Stop all services
-make logs           # Follow all logs (or: make logs LOG=platform)
-make status         # Show status and URLs
-make certs          # Generate SSL certificates
-make login          # Login to AWS ECR
-make clean          # Stop and remove all data (destructive)
-make generate-key   # Generate new encryption key
+export VAULT_TOKEN=$(cat volumes/openbao/init-keys.json | jq -r '.root_token')
+
+# Write a secret
+curl -X POST http://localhost:8200/v1/secret/data/myapp/config \
+  -H "X-Vault-Token: $VAULT_TOKEN" \
+  -d '{"data": {"username": "admin", "password": "secret"}}'
+
+# Read a secret
+curl http://localhost:8200/v1/secret/data/myapp/config \
+  -H "X-Vault-Token: $VAULT_TOKEN"
 ```
 
-## 🔧 Installing Adapters
+**Property encryption** — Two methods for encrypting adapter properties:
+- **Automatic**: Adapters with `propertiesDecorators.json` auto-encrypt marked properties. See [docs](https://docs.itential.com/docs/automatic-property-encryption-itential-platform).
+- **Manual**: Use `$SECRET_path $KEY_key` syntax in adapter properties. See [docs](https://docs.itential.com/docs/manual-property-encryption-itential-platform).
+
+If OpenBao is sealed after restart: `./scripts/configure-openbao.sh`
+</details>
+
+For detailed usage, see [docs/openbao](docs/openbao/).
+
+## Gateway5 / Gateway Manager
+
+Gateway5 connects to Platform via Gateway Manager. `make setup` handles everything automatically:
+
+1. Generates client certificates (`volumes/gateway5/certificates/`)
+2. Uploads certificates to Platform via API
+3. Configures RBAC (assigns gateway roles to admin)
+4. Creates and enables the gateway cluster
+
+If automatic configuration fails, the script displays manual instructions. See [Gateway Manager docs](https://docs.itential.com/docs/iag5-deploy-container#step-3-create-gateway-manager-certificates).
+
+## Installing Adapters
 
 ```bash
 cd volumes/platform/adapters/
@@ -228,244 +306,79 @@ make up  # Restart to load adapter
 
 Find adapters at [Itential Automation Marketplace](https://www.itential.com/automation-marketplace/).
 
-## 📋 Gateway4 Assets
-
-Playbooks and scripts must be executable to appear in the Gateway4 UI:
+## Debugging
 
 ```bash
-chmod +x volumes/gateway4/playbooks/*.yml
-chmod +x volumes/gateway4/scripts/*.py
-```
-
-> **Note**: `make setup` handles this automatically.
-
-## 🔑 LDAP Authentication
-
-OpenLDAP is available as an optional service for testing enterprise LDAP authentication with Itential Platform.
-
-### Enabling LDAP (Automatic Configuration)
-
-Add to your `.env` file:
-```bash
-LDAP_ENABLED=true
-```
-
-Then run `make setup` - the LDAP adapter will be configured automatically via API.
-
-After setup completes, you can log in with any LDAP user:
-
-| User | Password | Access |
-|------|----------|--------|
-| admin@itential | admin | Full admin (all roles + Gateway Manager) |
-| builder@itential | builder | LDAP group: builders |
-| operator@itential | operator | LDAP group: operators |
-
-> **Note**: The `admin@itential` user automatically receives all roles from the local admin account and is added to `admin_group` for Gateway Manager access.
-
-### Manual LDAP Start (without auto-config)
-
-```bash
-# Start Platform with LDAP container only
-docker compose --profile platform --profile ldap up -d
-
-# Configure LDAP adapter manually
-./scripts/configure-ldap.sh
-```
-
-### LDAP Connection Details
-
-| Property | Value |
-|----------|-------|
-| Host (from containers) | openldap |
-| Host (from host) | localhost |
-| Port | 389 (container) / 3389 (host) |
-| Admin DN | cn=admin,dc=itential,dc=io |
-| Admin Password | admin |
-| Base DN | dc=itential,dc=io |
-
-For advanced LDAP configuration, see the [official documentation](https://docs.itential.com/docs/configuring-open-ldap-iap).
-
-## 🤖 MCP Server (LLM Integration)
-
-The MCP (Model Context Protocol) server enables LLM tools like Claude Code and Claude Desktop to interact with Itential Platform.
-
-### Enabling MCP
-
-Add to your `.env` file:
-```bash
-MCP_ENABLED=true
-```
-
-Then run `make setup` or `make up`.
-
-### Configuration Options
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `MCP_ENABLED` | Enable MCP server | `false` |
-| `MCP_TRANSPORT` | Transport mode: `sse` or `stdio` | `sse` |
-| `MCP_SSE_PORT` | Port for SSE transport | `8000` |
-| `MCP_PLATFORM_USER` | Platform username | `admin` |
-| `MCP_PLATFORM_PASSWORD` | Platform password | `admin` |
-
-### Usage with Claude Desktop
-
-See [docs/itential-mcp](docs/itential-mcp/) for Claude Desktop configuration examples.
-
-For more information, see [itential-mcp](https://github.com/itential/itential-mcp).
-
-## 🔐 OpenBao (Secrets Management)
-
-[OpenBao](https://openbao.org/) is a Vault-compatible secrets management solution available as an optional service for storing and retrieving sensitive data.
-
-### Enabling OpenBao
-
-Add to your `.env` file:
-```bash
-OPENBAO_ENABLED=true
-```
-
-Then run `make setup`. The setup script will:
-1. Start the OpenBao container
-2. Initialize and unseal OpenBao automatically
-3. Save the root token and unseal keys to `volumes/openbao/init-keys.json`
-4. Enable the KV v2 secrets engine
-5. Configure Platform environment variables for Vault integration
-6. Install and configure the HashiCorp Vault adapter in Platform
-
-### Configuration Options
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `OPENBAO_ENABLED` | Enable OpenBao server | `false` |
-| `OPENBAO_VERSION` | OpenBao image version | `2` |
-| `OPENBAO_PORT` | API port | `8200` |
-
-### How It Works
-
-OpenBao runs with **persistent file storage**:
-- Data persists across container restarts in the `openbao-data` Docker volume
-- Requires initialization on first run (handled automatically by `make setup`)
-- Requires unsealing after restart (handled automatically by `configure-openbao.sh`)
-- Root token is generated during initialization and saved locally
-
-Platform is automatically configured with these environment variables:
-- `ITENTIAL_VAULT_URL=http://openbao:8200`
-- `ITENTIAL_VAULT_AUTH_METHOD=token`
-- `ITENTIAL_VAULT_TOKEN=/opt/vault/token.txt` (file path, token written to `volumes/platform/vault/token.txt`)
-- `ITENTIAL_VAULT_SECRETS_ENDPOINT=secret/data`
-
-### Quick Start
-
-After `make setup`, get your root token:
-```bash
-# View root token from init keys
-cat volumes/openbao/init-keys.json | jq -r '.root_token'
-
-# Or view the token file
-cat volumes/platform/vault/token.txt
-```
-
-Write and read secrets:
-```bash
-# Set your token (replace with actual token)
-export VAULT_TOKEN=$(cat volumes/openbao/init-keys.json | jq -r '.root_token')
-
-# Write a secret using curl
-curl -X POST http://localhost:8200/v1/secret/data/myapp/config \
-  -H "X-Vault-Token: $VAULT_TOKEN" \
-  -d '{"data": {"username": "admin", "password": "secret"}}'
-
-# Read a secret
-curl http://localhost:8200/v1/secret/data/myapp/config \
-  -H "X-Vault-Token: $VAULT_TOKEN"
-```
-
-### Using the OpenBao UI
-
-Access the web UI at http://localhost:8200 and log in with your root token.
-
-### After Restart
-
-If OpenBao is sealed after a container restart, run:
-```bash
-./scripts/configure-openbao.sh
-```
-
-For detailed usage examples, see [docs/openbao](docs/openbao/).
-
-### Property Encryption
-
-When OpenBao is enabled, Platform supports two methods for encrypting sensitive adapter properties:
-
-#### Automatic Property Encryption
-
-Adapters with `propertiesDecorators.json` files automatically encrypt marked properties (like passwords and API tokens) and store them in OpenBao.
-
-**How it works:**
-1. Adapter defines sensitive properties in `propertiesDecorators.json`
-2. When you save adapter config via UI or API, values are encrypted and stored in OpenBao
-3. Values are retrieved from OpenBao at runtime (never stored in MongoDB plaintext)
-
-**Requirements:**
-- `OPENBAO_ENABLED=true`
-- `ITENTIAL_VAULT_READ_ONLY=false` (default when auto-configured)
-
-See [Automatic Property Encryption](https://docs.itential.com/docs/automatic-property-encryption-itential-platform) for details.
-
-#### Manual Property Encryption ($SECRET syntax)
-
-Reference pre-existing secrets in OpenBao using the `$SECRET` syntax in adapter properties:
-
-```bash
-# Create a secret in OpenBao
-export VAULT_TOKEN=$(cat volumes/openbao/init-keys.json | jq -r '.root_token')
-curl -X POST http://localhost:8200/v1/secret/data/adapters/myapi \
-  -H "X-Vault-Token: $VAULT_TOKEN" \
-  -d '{"data": {"password": "supersecret", "apikey": "abc123"}}'
-
-# Reference in adapter property (via UI or API)
-# password field: "$SECRET_adapters/myapi $KEY_password"
-```
-
-An example secret is automatically created during setup at `secret/example/credentials` for testing.
-
-See [Manual Property Encryption](https://docs.itential.com/docs/manual-property-encryption-itential-platform) for details.
-
-## 🔑 Gateway5 / Gateway Manager
-
-Gateway5 connects to Platform via Gateway Manager. The setup is fully automated:
-
-1. Generates client certificates (`volumes/gateway5/certificates/`)
-2. Uploads certificates to Platform via API
-3. Configures RBAC (assigns gateway roles to admin)
-4. Creates and enables the gateway cluster
-
-If automatic configuration fails, the script displays manual instructions.
-
-See [Gateway Manager Documentation](https://docs.itential.com/docs/iag5-deploy-container#step-3-create-gateway-manager-certificates).
-
-## 🐞 Debugging
-
-```bash
-# Shell access (use podman instead of docker for Podman users)
+# Shell access
 docker exec -it platform /bin/sh
 docker exec -it gateway4 /bin/sh
 docker exec -it gateway5 sh
 
-# MongoDB shell
+# Database access
 docker exec -it mongodb mongosh
-
-# Redis CLI
 docker exec -it redis redis-cli
 
-# Check environment
+# Check platform environment
 docker exec platform env | grep ITENTIAL
 ```
 
-> **Podman users**: Replace `docker` with `podman` in the commands above, or use `podman-docker` for automatic compatibility.
+## Using Podman
 
-## 📚 Additional Resources
+This project is OCI-compliant and works with Podman. The simplest approach is to install Docker CLI emulation:
+
+```bash
+# Fedora/RHEL/CentOS
+sudo dnf install podman-docker
+
+# Ubuntu/Debian
+sudo apt install podman-docker
+```
+
+With this installed, all `make` commands work unchanged.
+
+<details>
+<summary>Manual podman commands</summary>
+
+```bash
+podman-compose --profile platform up -d
+podman-compose --profile platform down
+podman-compose logs -f
+
+# ECR auth
+aws ecr get-login-password --region us-east-2 | \
+  podman login --username AWS --password-stdin 497639811223.dkr.ecr.us-east-2.amazonaws.com
+```
+</details>
+
+## File Structure
+
+```
+itential-dev-stack/
+├── docker-compose.yml      # Service definitions
+├── .env                    # Your configuration (git-ignored)
+├── .env.example            # Configuration template
+├── defaults.env            # Default values (version-controlled)
+├── Makefile                # Make commands
+├── scripts/
+│   ├── setup.sh                     # First-time setup orchestrator
+│   ├── generate-certificates.sh     # SSL cert generation
+│   ├── configure-gateway-manager.sh # Gateway Manager config
+│   ├── configure-ldap.sh           # LDAP adapter config
+│   ├── configure-openbao.sh        # OpenBao init/unseal
+│   └── sync-admin-roles.sh         # Admin role sync
+├── docs/                   # Additional documentation
+├── volumes/
+│   ├── platform/           # Adapters, SSL certs, vault token
+│   ├── gateway4/           # Playbooks, scripts, data
+│   ├── gateway5/           # Certificates, scripts
+│   ├── ldap/               # LDAP bootstrap config
+│   ├── mcp/                # MCP logs
+│   └── openbao/            # OpenBao config
+└── dependencies/
+    └── mongodb-data/       # MongoDB persistent data
+```
+
+## Additional Resources
 
 - [Platform Environment Variables](https://docs.itential.com/docs/itential-platform-properties-environment-variables)
 - [Gateway4 Configuration](https://docs.itential.com/docs/configuration-for-iag)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     image: mongo:${MONGO_VERSION:-8.0}
     profiles: ["deps", "platform", "full"]
     ports:
-      - "${BIND_ADDRESS}27017:27017"
+      - "${BIND_ADDRESS}${MONGO_PORT:-27017}:27017"
     volumes:
       - type: bind
         source: ./dependencies/mongodb-data
@@ -58,7 +58,7 @@ services:
     image: redis:${REDIS_VERSION:-7.4}
     profiles: ["deps", "platform", "full"]
     ports:
-      - "${BIND_ADDRESS}6379:6379"
+      - "${BIND_ADDRESS}${REDIS_PORT:-6379}:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s
@@ -121,7 +121,7 @@ services:
         condition: service_completed_successfully
     ports:
       - "${BIND_ADDRESS}${PLATFORM_PORT:-3000}:3000"
-      - "${BIND_ADDRESS}8080:8080"
+      - "${BIND_ADDRESS}${GATEWAY_MANAGER_PORT:-8080}:8080"
     volumes:
       - type: bind
         source: ./volumes/platform/adapters
@@ -189,7 +189,7 @@ services:
 
   gateway4:
     container_name: gateway4
-    image: ${GATEWAY4_IMAGE:?GATEWAY4_IMAGE is required - check .env file}
+    image: ${GATEWAY4_IMAGE:-gateway4-not-configured}
     platform: linux/amd64
     profiles: ["gateway4", "full"]
     user: "${UID:-1000}:${GID:-1000}"
@@ -287,7 +287,7 @@ services:
 
   gateway5:
     container_name: gateway5
-    image: ${GATEWAY5_IMAGE:?GATEWAY5_IMAGE is required - check .env file}
+    image: ${GATEWAY5_IMAGE:-gateway5-not-configured}
     platform: linux/amd64
     profiles: ["gateway5", "full"]
     entrypoint:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -177,10 +177,30 @@ if [ "$OPENBAO_ENABLED" = "true" ]; then
     log_info "Vault token directory: created"
 fi
 
+# create all bind mount directories before docker compose (prevents errors)
+mkdir -p "$PROJECT_ROOT/dependencies/mongodb-data"
+mkdir -p "$PROJECT_ROOT/volumes/platform/adapters"
+mkdir -p "$PROJECT_ROOT/volumes/platform/ssl"
+mkdir -p "$PROJECT_ROOT/volumes/platform/vault"
+mkdir -p "$PROJECT_ROOT/volumes/gateway4/scripts"
+mkdir -p "$PROJECT_ROOT/volumes/gateway4/playbooks"
+mkdir -p "$PROJECT_ROOT/volumes/gateway4/ssl"
+mkdir -p "$PROJECT_ROOT/volumes/gateway5/certificates"
+mkdir -p "$PROJECT_ROOT/volumes/mcp/logs"
+mkdir -p "$PROJECT_ROOT/volumes/openbao/config"
+
 log_section "starting services"
 
 # build profile list based on enabled services
-PROFILES="--profile full"
+PROFILES="--profile ${STACK_PROFILE:-full}"
+if [ "$GATEWAY4_ENABLED" = "true" ]; then
+    PROFILES="$PROFILES --profile gateway4"
+    log_info "Gateway4 enabled"
+fi
+if [ "$GATEWAY5_ENABLED" = "true" ]; then
+    PROFILES="$PROFILES --profile gateway5"
+    log_info "Gateway5 enabled"
+fi
 if [ "$LDAP_ENABLED" = "true" ]; then
     PROFILES="$PROFILES --profile ldap"
     log_info "LDAP enabled"


### PR DESCRIPTION
## Summary
- Add `STACK_PROFILE` variable to control which base services start (`full`, `platform`, `deps`) via `make setup` and `make up`
- Add `GATEWAY4_ENABLED` / `GATEWAY5_ENABLED` flags for independent gateway control on top of any base profile
- Make all host ports configurable via `.env` (`MONGO_PORT`, `REDIS_PORT`, `GATEWAY_MANAGER_PORT` — previously hardcoded)
- Make gateway image variables optional with safe defaults so Docker Compose doesn't error when gateways are disabled
- Create all bind mount directories in `setup.sh` before `docker compose up` to prevent bind mount errors on fresh clones
- Document JFrog as an alternative image registry alongside AWS ECR in `.env.example` and README

## Motivation
Running the full stack isn't always needed — developers often just need Platform + dependencies. Previously, `make setup` always used `--profile full`, requiring all gateway images to be available even when not needed. This change makes the stack modular and avoids port conflicts with existing local services.

## Test plan
- [ ] `make setup` with `STACK_PROFILE=platform` starts only MongoDB, Redis, and Platform
- [ ] `STACK_PROFILE=platform` + `GATEWAY5_ENABLED=true` adds Gateway5 without Gateway4
- [ ] `STACK_PROFILE=full` (default) behaves as before
- [ ] Commented-out gateway images in `.env` no longer cause interpolation errors
- [ ] Custom port overrides (`MONGO_PORT`, `REDIS_PORT`, `GATEWAY_MANAGER_PORT`) work correctly
- [ ] Fresh clone with `make setup` succeeds (bind mount directories created automatically)