### PR TITLE
feat: enable platform HTTPS by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,6 +121,7 @@ services:
         condition: service_completed_successfully
     ports:
       - "${BIND_ADDRESS}${PLATFORM_PORT:-3000}:3000"
+      - "${BIND_ADDRESS}${PLATFORM_HTTPS_PORT:-3443}:3443"
       - "${BIND_ADDRESS}${GATEWAY_MANAGER_PORT:-8080}:8080"
     volumes:
       - type: bind
@@ -154,6 +155,7 @@ services:
 
       # web server
       ITENTIAL_WEBSERVER_HTTP_PORT: 3000
+      ITENTIAL_WEBSERVER_HTTPS_ENABLED: true
       ITENTIAL_WEBSERVER_HTTPS_PORT: 3443
       ITENTIAL_WEBSERVER_HTTPS_KEY: "/etc/ssl/platform/key.pem"
       ITENTIAL_WEBSERVER_HTTPS_CERT: "/etc/ssl/platform/cert.pem"


### PR DESCRIPTION
## Description

OAuth clients in Platform are not allowed to use http and must authenticate using HTTPS. The dev stack already generates and mounts SSL certs into the platform container and sets the HTTPS port/key/cert env vars, but the HTTPS listener was not enabled on the platform side and host port `3443` was not published, so platform was only reachable over http. This change makes HTTPS available out of the box so OAuth client flows work against the dev stack without any extra configuration.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

## Changes Made

- Publish container port `3443` to the host from the `platform` service, overridable via a new `PLATFORM_HTTPS_PORT` variable that follows the same `${VAR:-default}` pattern as the other `*_PORT` overrides.
- Set `ITENTIAL_WEBSERVER_HTTPS_ENABLED: true` on the `platform` service so the platform actually starts its HTTPS listener (the cert/key paths and HTTPS port were already wired in but the listener itself was off).

## Testing

- [ ] `make clean && make setup` brings the stack up cleanly
- [ ] `https://localhost:3443/login` is reachable (self-signed cert warning expected)
- [ ] `http://localhost:3000/login` still reachable (no regression)
- [ ] OAuth client login flow succeeds against `https://localhost:3443`

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Code has been commented where necessary
- [ ] Tested with `make setup` or relevant profile
- [x] Commits follow conventional format (`type: subject`)
- [x] No secrets or credentials committed
- [ ] Documentation has been updated accordingly
- [x] PR has been labeled appropriately (`enhancement`, `bug`, `documentation`, `refactor`, `chore`)