### PR TITLE
feat: add iag5 and iag5-openbao make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Itential Dev Stack
 # run 'make help' to see available commands
 
-.PHONY: help setup up down logs status certs login clean generate-key
+.PHONY: help setup up down logs status certs login clean generate-key iag5 iag5-openbao _ensure-gateway5-image
 
 .DEFAULT_GOAL := help
 
@@ -44,12 +44,17 @@ ifeq ($(OPENBAO_ENABLED),true)
   PROFILES += --profile openbao
 endif
 
+# standalone gateway5/openbao deploys load the full compose file, which references the
+# Platform-only ITENTIAL_ENCRYPTION_KEY; supply a placeholder so loading succeeds without
+# a .env (the platform service is never started under these profiles)
+IAG5_ENV := ITENTIAL_ENCRYPTION_KEY=$${ITENTIAL_ENCRYPTION_KEY:-iag5-standalone-unused}
+
 help: ## Show available commands
 	@echo "Itential Dev Stack"
 	@echo ""
 	@echo "Usage: make [target]"
 	@echo ""
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' Makefile | \
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' Makefile | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
 	@echo ""
 	@echo "First time? Run: make setup"
@@ -60,6 +65,30 @@ setup: ## First-time setup (generates key, certs, starts services, configures Ga
 up: ## Start all services
 	@docker compose $(PROFILES) up -d
 	@$(MAKE) --no-print-directory status
+
+iag5: _ensure-gateway5-image ## Deploy IAG5 (Automation Gateway 5) standalone, no Platform
+	@./scripts/generate-certificates.sh --quiet
+	@$(IAG5_ENV) GATEWAY5_CONNECT_HOSTS= docker compose --profile gateway5 up -d
+	@$(MAKE) --no-print-directory status
+
+iag5-openbao: _ensure-gateway5-image ## Deploy IAG5 + OpenBao side by side (no wiring)
+	@./scripts/generate-certificates.sh --quiet
+	@$(IAG5_ENV) GATEWAY5_CONNECT_HOSTS= docker compose --profile gateway5 --profile openbao up -d
+	@./scripts/configure-openbao.sh --init-only
+	@$(MAKE) --no-print-directory status
+
+# ensure the gateway5 image is available locally (pulling if needed) before standalone deploys
+_ensure-gateway5-image:
+	@docker image inspect $(GATEWAY5_IMAGE) >/dev/null 2>&1 || { \
+		echo "IAG5 image not found locally: $(GATEWAY5_IMAGE)"; \
+		echo "Attempting to pull..."; \
+		$(IAG5_ENV) docker compose --profile gateway5 pull gateway5 || { \
+			echo ""; \
+			echo "Could not pull the IAG5 image."; \
+			echo "If this is an AWS ECR image, run 'make login' first, then retry."; \
+			exit 1; \
+		}; \
+	}
 
 down: ## Stop all services
 	@docker compose $(PROFILES) down

--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ Different platform images may run as different UIDs. The init container sets log
 |---------|-------------|
 | `make setup` | First-time setup (key, certs, start, configure) |
 | `make up` | Start services |
+| `make iag5` | Deploy IAG5 (Gateway 5) standalone, no Platform |
+| `make iag5-openbao` | Deploy IAG5 + OpenBao side by side (no wiring) |
 | `make down` | Stop services |
 | `make logs` | Follow all logs (or: `make logs LOG=platform`) |
 | `make status` | Show status and URLs |
@@ -304,6 +306,34 @@ Gateway5 connects to Platform via Gateway Manager. `make setup` handles everythi
 4. Creates and enables the gateway cluster
 
 If automatic configuration fails, the script displays manual instructions. See [Gateway Manager docs](https://docs.itential.com/docs/iag5-deploy-container#step-3-create-gateway-manager-certificates).
+
+### Standalone IAG5 (no Platform)
+
+To work on or demo IAG5 without the full Platform stack, deploy it on its own:
+
+```bash
+make iag5            # IAG5 only
+make iag5-openbao    # IAG5 + OpenBao (side by side, initialized and unsealed)
+```
+
+Both targets generate certificates first and skip the Gateway Manager connection, so
+IAG5 runs without a Platform to register with. They require only the IAG5 image (no
+encryption key or `.env`); if the image is missing, the target attempts a pull and
+points you to `make login` for AWS ECR access.
+
+`make iag5-openbao` brings up OpenBao alongside IAG5 and initializes it, but does not
+wire IAG5 to consume OpenBao secrets — the two simply run together. Get the OpenBao root
+token from `volumes/openbao/init-keys.json`.
+
+Tear down with `make down` (covers IAG5 via the `full` profile). To also stop OpenBao:
+
+```bash
+docker compose --profile openbao down
+```
+
+> **Note**: Suppressing the Gateway Manager connection relies on passing an empty
+> `GATEWAY5_CONNECT_HOSTS`. Confirm against your IAG5 version if you see registration
+> attempts in `docker logs gateway5`.
 
 ## 🔧 Installing Adapters
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -311,7 +311,9 @@ services:
       GATEWAY_APPLICATION_WORKING_DIR: "/etc/gateway"
 
       # gw manager connection
-      GATEWAY_CONNECT_HOSTS: "platform:8080"
+      # default targets Platform's Gateway Manager; the iag5 make targets pass an
+      # empty GATEWAY5_CONNECT_HOSTS to run standalone without a manager
+      GATEWAY_CONNECT_HOSTS: "${GATEWAY5_CONNECT_HOSTS-platform:8080}"
       GATEWAY_CONNECT_CERTIFICATE_FILE: "/etc/ssl/gateway5/gw-manager.pem"
       GATEWAY_CONNECT_PRIVATE_KEY_FILE: "/etc/ssl/gateway5/gw-manager-key.pem"
       GATEWAY_CONNECT_INSECURE_TLS: "true"

--- a/docs/openbao/README.md
+++ b/docs/openbao/README.md
@@ -37,6 +37,13 @@ cat volumes/openbao/init-keys.json | jq -r '.root_token'
 grep ITENTIAL_VAULT_TOKEN .env
 ```
 
+### Without Platform
+
+To run OpenBao alongside IAG5 without the rest of the stack, use `make iag5-openbao`.
+This brings up OpenBao initialized and unsealed, but does not wire it into Platform (no
+Vault adapter, no `.env` integration). The two services run side by side. The root token
+is still saved to `volumes/openbao/init-keys.json`.
+
 ## Accessing OpenBao
 
 ### Web UI

--- a/scripts/configure-openbao.sh
+++ b/scripts/configure-openbao.sh
@@ -17,6 +17,18 @@ log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
+# parse args
+# --init-only: initialize, unseal, and enable KV (plus example secrets) without any
+# Platform integration. Used by the iag5-openbao target where no Platform is running.
+INIT_ONLY=false
+for arg in "$@"; do
+    case "$arg" in
+        --init-only)
+            INIT_ONLY=true
+            ;;
+    esac
+done
+
 # check for jq
 if ! command -v jq &>/dev/null; then
     log_error "jq is required but not installed"
@@ -157,8 +169,8 @@ else
     log_info "KV secrets engine already enabled at secret/"
 fi
 
-# update .env and token file if OPENBAO_ENABLED
-if [ "$OPENBAO_ENABLED" = "true" ]; then
+# update .env and token file if OPENBAO_ENABLED (skipped in init-only mode)
+if [ "$INIT_ONLY" = false ] && [ "$OPENBAO_ENABLED" = "true" ]; then
 
     # token file path (Platform expects a file path, not raw token value)
     VAULT_TOKEN_DIR="$PROJECT_ROOT/volumes/platform/vault"
@@ -210,6 +222,9 @@ EOF
 fi
 
 log_info "OpenBao configuration complete!"
+
+# everything below requires a running Platform; skip it entirely in init-only mode
+if [ "$INIT_ONLY" = false ]; then
 
 # ==========================================================================
 # VAULT ADAPTER INSTALLATION AND CONFIGURATION
@@ -443,6 +458,8 @@ fi
 
 # export ADAPTER_INSTALLED for setup.sh to detect if Platform restart is needed
 export ADAPTER_INSTALLED
+
+fi  # end Platform-dependent configuration
 
 # ==========================================================================
 # CREATE EXAMPLE SECRETS FOR TESTING MANUAL PROPERTY ENCRYPTION


### PR DESCRIPTION
## Description

Adds two `make` targets for deploying Automation Gateway 5 (IAG5) in isolation: `make iag5` (standalone) and `make iag5-openbao` (IAG5 plus an initialized OpenBao, side by side). This gives a fast, lightweight path to work on or demo IAG5 without booting the full Platform stack.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `docker-compose.yml`: parameterize gateway5's `GATEWAY_CONNECT_HOSTS` as `${GATEWAY5_CONNECT_HOSTS-platform:8080}` so standalone targets can suppress the Gateway Manager connection. Default is unchanged.
- `scripts/configure-openbao.sh`: add an `--init-only` mode that initializes, unseals, and enables KV v2 (plus example secrets) while skipping all Platform-dependent wiring (no `.env` integration, no Vault adapter, no Platform API wait).
- `Makefile`: add `iag5` and `iag5-openbao` targets, a `_ensure-gateway5-image` helper that pulls the image (pointing to `make login` on failure), and an `IAG5_ENV` placeholder so standalone deploys load the compose file without a Platform encryption key. Widen the `help` regex to include digits so the new targets list.
- `README.md` and `docs/openbao/README.md`: document the new targets and the Platform-less OpenBao flow.

## Testing

```bash
make help                 # iag5 and iag5-openbao now listed
make iag5                 # brings up only gateway5 (no Platform/Mongo/Redis)
make iag5-openbao         # brings up gateway5 + openbao, initialized and unsealed
```

Verified via `docker compose ... up --dry-run` that each target selects only the expected containers and succeeds with no `.env` / encryption key present.

> Note: suppressing the Gateway Manager connection relies on passing an empty `GATEWAY_CONNECT_HOSTS`. This resolves correctly in compose; the runtime effect should be confirmed against a running IAG5 (`docker logs gateway5`).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed
- [x] No change to existing `make up` / `make setup` / `make down` behavior

Closes #33